### PR TITLE
Add Diffblue tests

### DIFF
--- a/waltz-common/pom.xml
+++ b/waltz-common/pom.xml
@@ -58,5 +58,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>1.6.5</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/waltz-common/src/test/java/com/khartec/waltz/common/AliasesTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/AliasesTest.java
@@ -1,0 +1,37 @@
+package com.khartec.waltz.common;
+
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+
+public class AliasesTest {
+
+  @Test
+  public void lookupTest() throws Exception {
+    // Arrange
+    Aliases<Object> aliases = new Aliases<Object>();
+    String alias = "aaaaa";
+
+    // Act
+    Optional<Object> actual = aliases.lookup(alias);
+
+    // Assert
+    assertEquals("Optional.empty", actual.toString());
+  }
+
+  @Test
+  public void registerTest() throws Exception {
+    // Arrange
+    Aliases<Object> aliases = new Aliases<Object>();
+    String val = "aaaaa";
+    String[] stringArray = new String[]{"aaaaa", "aaaaa", "aakaa"};
+
+    // Act
+    aliases.register(val, stringArray);
+
+    // Assert
+    assertEquals(3, stringArray.length);
+  }
+}

--- a/waltz-common/src/test/java/com/khartec/waltz/common/ArrayUtilitiesTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/ArrayUtilitiesTest.java
@@ -1,0 +1,57 @@
+package com.khartec.waltz.common;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class ArrayUtilitiesTest {
+
+  @Test
+  public void initialTest() throws Exception {
+    // Arrange
+    Object[] bits = new Object[]{"aaaaa", "aaaaa", "aaaaa"};
+
+    // Act
+    Object[] actual = ArrayUtilities.<Object>initial(bits);
+
+    // Assert
+    assertEquals(2, actual.length);
+  }
+
+  @Test
+  public void isEmptyTest() throws Exception {
+    // Arrange
+    Object[] arr = new Object[]{"aaaaa", "aaaaa", "aaaaa"};
+
+    // Act
+    boolean actual = ArrayUtilities.<Object>isEmpty(arr);
+
+    // Assert
+    assertFalse(actual);
+  }
+
+  @Test
+  public void lastTest() throws Exception {
+    // Arrange
+    Object[] arr = new Object[]{"aaaaa", "aaaaa", "aaaaa"};
+
+    // Act
+    Object actual = ArrayUtilities.<Object>last(arr);
+
+    // Assert
+    assertEquals("aaaaa", actual);
+  }
+
+  @Test
+  public void sumTest() throws Exception {
+    // Arrange
+    int[] arr = new int[]{1, 1, 1, 1, 1, 1, 1, 655361};
+
+    // Act
+    int actual = ArrayUtilities.sum(arr);
+
+    // Assert
+    assertEquals(655368, actual);
+  }
+}

--- a/waltz-common/src/test/java/com/khartec/waltz/common/BuilderTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/BuilderTest.java
@@ -1,0 +1,50 @@
+package com.khartec.waltz.common;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class BuilderTest {
+
+  @Test
+  public void addAllTest() throws Exception {
+    // Arrange
+    ListUtilities.Builder<Object> builder = new ListUtilities.Builder<Object>();
+    ArrayList<Object> arrayList = new ArrayList<Object>();
+    arrayList.add("aaaaa");
+
+    // Act
+    builder.addAll(arrayList);
+
+    // Assert
+    assertEquals(1, arrayList.size());
+  }
+
+  @Test
+  public void addAllTest2() throws Exception {
+    // Arrange
+    ListUtilities.Builder<Object> builder = new ListUtilities.Builder<Object>();
+    Object[] objectArray = new Object[]{"aaaaa", "aaaaa", "aaaaa"};
+
+    // Act
+    builder.addAll(objectArray);
+
+    // Assert
+    assertEquals(3, objectArray.length);
+  }
+
+  @Test
+  public void buildTest() throws Exception {
+    // Arrange
+    ListUtilities.Builder<Object> builder = new ListUtilities.Builder<Object>();
+
+    // Act
+    List<Object> actual = builder.build();
+
+    // Assert
+    assertEquals(0, actual.size());
+  }
+}

--- a/waltz-common/src/test/java/com/khartec/waltz/common/ChecksTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/ChecksTest.java
@@ -1,0 +1,128 @@
+package com.khartec.waltz.common;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+
+public class ChecksTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void checkFalseTest() throws Exception {
+    // Arrange
+    boolean b = true;
+    String message = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    Checks.checkFalse(b, message);
+  }
+
+  @Test
+  public void checkNotEmptyTest() throws Exception {
+    // Arrange
+    String str = "aaaaa";
+    String message = "aaaaa";
+
+    // Act
+    String actual = Checks.checkNotEmpty(str, message);
+
+    // Assert
+    assertEquals("aaaaa", actual);
+  }
+
+  @Test
+  public void checkNotEmptyTest2() throws Exception {
+    // Arrange
+    ArrayList<Object> arrayList = new ArrayList<Object>();
+    arrayList.add("aaaaa");
+    String message = "aaaaa";
+
+    // Act
+    Checks.<Object>checkNotEmpty(arrayList, message);
+
+    // Assert
+    assertEquals(1, arrayList.size());
+  }
+
+  @Test
+  public void checkNotEmptyTest3() throws Exception {
+    // Arrange
+    Object[] objectArray = new Object[]{"aaaaa", "aaaaa", "aaaaa"};
+    String message = "aaaak";
+
+    // Act
+    Checks.<Object>checkNotEmpty(objectArray, message);
+
+    // Assert
+    assertEquals(3, objectArray.length);
+  }
+
+  @Test
+  public void checkNotNullTest() throws Exception {
+    // Arrange
+    String string = "aaaaa";
+    String message = "aaaaa";
+    Object[] args = new Object[]{string, "aaaaa", "aaaka"};
+
+    // Act
+    Object actual = Checks.<Object>checkNotNull(string, message, args);
+
+    // Assert
+    assertEquals("aaaaa", actual);
+  }
+
+  @Test
+  public void checkOptionalIsPresentTest() throws Exception {
+    // Arrange
+    Optional<Object> optional = null;
+    String message = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    Checks.<Object>checkOptionalIsPresent(optional, message);
+  }
+
+  @Test
+  public void checkTrueTest() throws Exception {
+    // Arrange
+    boolean b = true;
+    String msg = "aaaaa";
+    Object[] objectArray = new Object[]{"aaaaa", "aaaaa", "aaaka"};
+
+    // Act
+    Checks.checkTrue(b, msg, objectArray);
+
+    // Assert
+    assertEquals(3, objectArray.length);
+  }
+
+  @Test
+  public void failTest() throws Exception {
+    // Arrange
+    String msg = "aaaaa";
+    Object[] args = new Object[]{"aaaaa", "aaaaa", "aaaak"};
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    Checks.fail(msg, args);
+  }
+
+  @Test
+  public void mkFailTest() throws Exception {
+    // Arrange
+    String msg = "aaaaa";
+    Object[] args = new Object[]{"aaaaa", "aaaaa", "aaaak"};
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    Checks.mkFail(msg, args);
+  }
+}

--- a/waltz-common/src/test/java/com/khartec/waltz/common/CollectionUtilitiesTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/CollectionUtilitiesTest.java
@@ -1,0 +1,91 @@
+package com.khartec.waltz.common;
+
+import org.junit.Test;
+import org.powermock.reflect.Whitebox;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+
+public class CollectionUtilitiesTest {
+
+  @Test
+  public void firstTest() throws Exception {
+    // Arrange
+    ArrayList<Object> arrayList = new ArrayList<Object>();
+    arrayList.add("aaaaa");
+
+    // Act
+    Object actual = CollectionUtilities.<Object>first(arrayList);
+
+    // Assert
+    assertEquals("aaaaa", actual);
+  }
+
+  @Test
+  public void headTest() throws Exception {
+    // Arrange
+    ArrayList<Object> arrayList = new ArrayList<Object>();
+    arrayList.add("aaaaa");
+
+    // Act
+    Optional<Object> actual = CollectionUtilities.<Object>head(arrayList);
+
+    // Assert
+    assertEquals("Optional[aaaaa]", actual.toString());
+  }
+
+  @Test
+  public void isEmptyTest() throws Exception {
+    // Arrange
+    ArrayList<Object> arrayList = new ArrayList<Object>();
+    arrayList.add("aaaaa");
+
+    // Act
+    boolean actual = CollectionUtilities.<Object>isEmpty(arrayList);
+
+    // Assert
+    assertFalse(actual);
+  }
+
+  @Test
+  public void maybeFirstTest() throws Exception {
+    // Arrange
+    ArrayList<Object> arrayList = new ArrayList<Object>();
+    arrayList.add("aaaaa");
+
+    // Act
+    Optional<Object> actual = CollectionUtilities.<Object>maybeFirst(arrayList);
+
+    // Assert
+    assertEquals("Optional[aaaaa]", actual.toString());
+  }
+
+  @Test
+  public void notEmptyTest() throws Exception {
+    // Arrange
+    ArrayList<Object> arrayList = new ArrayList<Object>();
+    arrayList.add("aaaaa");
+
+    // Act
+    boolean actual = CollectionUtilities.<Object>notEmpty(arrayList);
+
+    // Assert
+    assertTrue(actual);
+  }
+
+  @Test
+  public void sortTest() throws Exception {
+    // Arrange
+    ArrayList<Comparable> arrayList = new ArrayList<Comparable>();
+    arrayList.add(Whitebox.newInstance(Comparable.class));
+
+    // Act
+    List<Comparable> actual = CollectionUtilities.<Comparable>sort(arrayList);
+
+    // Assert
+    assertEquals(1, actual.size());
+  }
+}

--- a/waltz-common/src/test/java/com/khartec/waltz/common/DateTimeUtilitiesTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/DateTimeUtilitiesTest.java
@@ -21,10 +21,13 @@ package com.khartec.waltz.common;
 
 import org.junit.Test;
 
+import java.sql.Date;
+import java.sql.Timestamp;
 import java.time.LocalDate;
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static junit.framework.TestCase.assertNull;
+import static org.junit.Assert.assertEquals;
 
 public class DateTimeUtilitiesTest {
 
@@ -34,6 +37,93 @@ public class DateTimeUtilitiesTest {
         assertNull(DateTimeUtilities.toSqlDate((LocalDate) null));
         assertNull(DateTimeUtilities.toLocalDateTime(null));
         assertNull(DateTimeUtilities.toLocalDate(null));
+    }
+
+    @Test
+    public void nowUtcTest() throws Exception {
+        // Arrange and Act
+        LocalDateTime actual = DateTimeUtilities.nowUtc();
+
+        // Assert
+        assertEquals(2019, actual.getYear());
+    }
+
+    @Test
+    public void nowUtcTimestampTest() throws Exception {
+        // Arrange and Act
+        Timestamp actual = DateTimeUtilities.nowUtcTimestamp();
+
+        // Assert
+        assertEquals(119, actual.getYear());
+    }
+
+    @Test
+    public void toLocalDateTest() throws Exception {
+        // Arrange
+        java.util.Date date = new java.util.Date(1L);
+
+        // Act
+        LocalDate actual = DateTimeUtilities.toLocalDate(date);
+
+        // Assert
+        assertEquals(1970, actual.getYear());
+    }
+
+    @Test
+    public void toLocalDateTest2() throws Exception {
+        // Arrange
+        Timestamp timestamp = new Timestamp(1L);
+
+        // Act
+        LocalDate actual = DateTimeUtilities.toLocalDate(timestamp);
+
+        // Assert
+        assertEquals(1970, actual.getYear());
+    }
+
+    @Test
+    public void toLocalDateTimeTest() throws Exception {
+        // Arrange
+        java.util.Date date = new java.util.Date(1L);
+
+        // Act
+        LocalDateTime actual = DateTimeUtilities.toLocalDateTime(date);
+
+        // Assert
+        assertEquals(1970, actual.getYear());
+    }
+
+    @Test
+    public void toSqlDateTest() throws Exception {
+        // Arrange
+        java.util.Date date = new java.util.Date(1L);
+
+        // Act
+        java.sql.Date actual = DateTimeUtilities.toSqlDate(date);
+
+        // Assert
+        assertEquals(70, actual.getYear());
+    }
+
+    @Test
+    public void toSqlDateTest2() throws Exception {
+        // Arrange
+        LocalDate localDate = null;
+
+        // Act
+        Date actual = DateTimeUtilities.toSqlDate(localDate);
+
+        // Assert
+        assertEquals(null, actual);
+    }
+
+    @Test
+    public void todayTest() throws Exception {
+        // Arrange and Act
+        LocalDate actual = DateTimeUtilities.today();
+
+        // Assert
+        assertEquals(2019, actual.getYear());
     }
 
 }

--- a/waltz-common/src/test/java/com/khartec/waltz/common/DebugUtilitiesTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/DebugUtilitiesTest.java
@@ -1,0 +1,38 @@
+package com.khartec.waltz.common;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class DebugUtilitiesTest {
+
+  @Test
+  public void dumpTest() throws Exception {
+    // Arrange
+    HashMap<Object, Object> hashMap = new HashMap<Object, Object>();
+    hashMap.put("aaaaa", "aaaaa");
+
+    // Act
+    Map<Object, Object> actual = DebugUtilities.<Object, Object>dump(hashMap);
+
+    // Assert
+    assertTrue(actual instanceof HashMap);
+  }
+
+  @Test
+  public void logValueTest() throws Exception {
+    // Arrange
+    String string = "aaaaa";
+    Object[] ctx = new Object[]{"aaaaa", string, "aaaaa"};
+
+    // Act
+    Object actual = DebugUtilities.<Object>logValue(string, ctx);
+
+    // Assert
+    assertEquals("aaaaa", actual);
+  }
+}

--- a/waltz-common/src/test/java/com/khartec/waltz/common/DigestUtilitiesTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/DigestUtilitiesTest.java
@@ -1,0 +1,20 @@
+package com.khartec.waltz.common;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DigestUtilitiesTest {
+
+  @Test
+  public void digestTest() throws Exception {
+    // Arrange
+    byte[] bytes = new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+    // Act
+    String actual = DigestUtilities.digest(bytes);
+
+    // Assert
+    assertEquals("0zmbcmL7Vsue0FPWjbkpHEEIOcQ=", actual);
+  }
+}

--- a/waltz-common/src/test/java/com/khartec/waltz/common/FunctionUtilitiesTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/FunctionUtilitiesTest.java
@@ -31,4 +31,37 @@ public class FunctionUtilitiesTest {
         String result = FunctionUtilities.time("foo", Unchecked.supplier(() -> { Thread.sleep(500); return "a"; }));
         assertEquals("a", result);
     }
+
+    @Test
+    public void FunctionUtilitiesTest() throws Exception {
+        // Arrange and Act
+        new FunctionUtilities();
+    }
+
+    @Test
+    public void alwaysBiTest() throws Exception {
+        // Arrange
+        String result = "aaaaa";
+
+        // Act
+        FunctionUtilities.<Object, Object, Object>alwaysBi(result);
+    }
+
+    @Test
+    public void alwaysTest() throws Exception {
+        // Arrange
+        String result = "aaaaa";
+
+        // Act
+        FunctionUtilities.<Object, Object>always(result);
+    }
+
+    @Test
+    public void discardResultTest() throws Exception {
+        // Arrange
+        String x = "aaaaa";
+
+        // Act
+        FunctionUtilities.discardResult(x);
+    }
 }

--- a/waltz-common/src/test/java/com/khartec/waltz/common/IOUtilitiesTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/IOUtilitiesTest.java
@@ -1,0 +1,82 @@
+package com.khartec.waltz.common;
+
+import org.junit.Test;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class IOUtilitiesTest {
+
+  @Test
+  public void copyStreamTest() throws Exception {
+    // Arrange
+    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(
+        new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+    // Act
+    IOUtilities.copyStream(byteArrayInputStream, output);
+
+    // Assert
+    assertEquals(0, byteArrayInputStream.available());
+  }
+
+  @Test
+  public void getFileResourceTest() throws Exception {
+    // Arrange
+    String fileName = "aaaaa";
+
+    // Act
+    Resource actual = IOUtilities.getFileResource(fileName);
+
+    // Assert
+    String path = ((FileSystemResource) actual).getPath();
+    assertEquals("aaaaa", actual.getFilename());
+  }
+
+  @Test
+  public void readAsStringTest() throws Exception {
+    // Arrange
+    ByteArrayInputStream stream = new ByteArrayInputStream(
+        new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+
+    // Act
+    String actual = IOUtilities.readAsString(stream);
+
+    // Assert
+    assertEquals(
+        "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+        actual);
+  }
+
+  @Test
+  public void readLinesTest() throws Exception {
+    // Arrange
+    ByteArrayInputStream stream = new ByteArrayInputStream(
+        new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+
+    // Act
+    List<String> actual = IOUtilities.readLines(stream);
+
+    // Assert
+    assertEquals(1, actual.size());
+  }
+
+  @Test
+  public void streamLinesTest() throws Exception {
+    // Arrange
+    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(
+        new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+
+    // Act
+    IOUtilities.streamLines(byteArrayInputStream);
+
+    // Assert
+    assertEquals(24, byteArrayInputStream.available());
+  }
+}

--- a/waltz-common/src/test/java/com/khartec/waltz/common/ListUtilitiesTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/ListUtilitiesTest.java
@@ -1,0 +1,171 @@
+package com.khartec.waltz.common;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class ListUtilitiesTest {
+
+  @Test
+  public void appendTest() throws Exception {
+    // Arrange
+    ArrayList<Object> arrayList = new ArrayList<Object>();
+    arrayList.add("aaaaa");
+    String t = "aaaaa";
+
+    // Act
+    List<Object> actual = ListUtilities.<Object>append(arrayList, t);
+
+    // Assert
+    assertEquals(2, actual.size());
+  }
+
+  @Test
+  public void asListTest() throws Exception {
+    // Arrange
+    Object[] ts = new Object[]{"aaaaa", "aaaaa", "aaaaa"};
+
+    // Act
+    List<Object> actual = ListUtilities.<Object>asList(ts);
+
+    // Assert
+    assertEquals(3, actual.size());
+  }
+
+  @Test
+  public void builderTest() throws Exception {
+    // Arrange
+    Class<Object> cls = null;
+
+    // Act
+    ListUtilities.<Object>builder(cls);
+  }
+
+  @Test
+  public void compactTest() throws Exception {
+    // Arrange
+    ArrayList<Object> arrayList = new ArrayList<Object>();
+    arrayList.add("aaaaa");
+
+    // Act
+    List<Object> actual = ListUtilities.<Object>compact(arrayList);
+
+    // Assert
+    assertEquals(1, actual.size());
+  }
+
+  @Test
+  public void concatTest() throws Exception {
+    // Arrange
+    ArrayList<Object> arrayList = new ArrayList<Object>();
+    arrayList.add("aaaaa");
+    ArrayList<Object> arrayList1 = new ArrayList<Object>();
+    arrayList1.add("aaaaa");
+    ArrayList<Object> arrayList2 = new ArrayList<Object>();
+    arrayList2.add("aakaa");
+    List<Object>[] tss = new List[]{arrayList, arrayList1, arrayList2};
+
+    // Act
+    List<Object> actual = ListUtilities.<Object>concat(tss);
+
+    // Assert
+    assertEquals(3, actual.size());
+  }
+
+  @Test
+  public void dropTest() throws Exception {
+    // Arrange
+    ArrayList<Object> arrayList = new ArrayList<Object>();
+    arrayList.add("aaaaa");
+    int count = 1;
+
+    // Act
+    List<Object> actual = ListUtilities.<Object>drop(arrayList, count);
+
+    // Assert
+    assertEquals(0, actual.size());
+  }
+
+  @Test
+  public void ensureNotNullTest() throws Exception {
+    // Arrange
+    ArrayList<Object> arrayList = new ArrayList<Object>();
+    arrayList.add("aaaaa");
+
+    // Act
+    List<Object> actual = ListUtilities.<Object>ensureNotNull(arrayList);
+
+    // Assert
+    assertEquals(1, actual.size());
+  }
+
+  @Test
+  public void integerRangeTest() throws Exception {
+    // Arrange
+    int startInclusive = 1;
+    int endExclusive = 1;
+
+    // Act
+    List<Integer> actual = ListUtilities.integerRange(startInclusive, endExclusive);
+
+    // Assert
+    assertEquals(0, actual.size());
+  }
+
+  @Test
+  public void isEmptyTest() throws Exception {
+    // Arrange
+    ArrayList<Object> arrayList = new ArrayList<Object>();
+    arrayList.add("aaaaa");
+
+    // Act
+    boolean actual = ListUtilities.<Object>isEmpty(arrayList);
+
+    // Assert
+    assertFalse(actual);
+  }
+
+  @Test
+  public void newArrayListTest() throws Exception {
+    // Arrange
+    Object[] ts = new Object[]{"aaaaa", "aaaaa", "aaaaa"};
+
+    // Act
+    ArrayList<Object> actual = ListUtilities.<Object>newArrayList(ts);
+
+    // Assert
+    assertEquals(3, actual.size());
+  }
+
+  @Test
+  public void pushTest() throws Exception {
+    // Arrange
+    ArrayList<Object> arrayList = new ArrayList<Object>();
+    String string = "aaaaa";
+    arrayList.add(string);
+    Object[] elems = new Object[]{"aaaaa", string, "aaaaa"};
+
+    // Act
+    List<Object> actual = ListUtilities.<Object>push(arrayList, elems);
+
+    // Assert
+    assertEquals(4, actual.size());
+  }
+
+  @Test
+  public void reverseTest() throws Exception {
+    // Arrange
+    ArrayList<Object> arrayList = new ArrayList<Object>();
+    arrayList.add("aaaaa");
+
+    // Act
+    List<Object> actual = ListUtilities.<Object>reverse(arrayList);
+
+    // Assert
+    assertEquals(1, actual.size());
+  }
+}

--- a/waltz-common/src/test/java/com/khartec/waltz/common/MapBuilderTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/MapBuilderTest.java
@@ -21,10 +21,11 @@ package com.khartec.waltz.common;
 
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-
+import static org.junit.Assert.assertSame;
 
 public class MapBuilderTest {
 
@@ -52,6 +53,46 @@ public class MapBuilderTest {
         assertEquals(2, m.size());
         assertEquals(Integer.valueOf(1), m.get("a"));
         assertEquals("bob", m.get("b"));
+    }
+
+    @Test
+    public void addTest() throws Exception {
+        // Arrange
+        MapBuilder<Object, Object> mapBuilder = new MapBuilder<Object, Object>();
+        String k = "aaaaa";
+        String v = "aaaaa";
+
+        // Act
+        MapBuilder<Object, Object> actual = mapBuilder.add(k, v);
+
+        // Assert
+        assertSame(mapBuilder, actual);
+    }
+
+    @Test
+    public void buildTest() throws Exception {
+        // Arrange
+        MapBuilder<Object, Object> mapBuilder = new MapBuilder<Object, Object>();
+
+        // Act
+        Map<Object, Object> actual = mapBuilder.build();
+
+        // Assert
+        assertEquals(0, actual.size());
+    }
+
+    @Test
+    public void fromTest() throws Exception {
+        // Arrange
+        MapBuilder<Object, Object> mapBuilder = new MapBuilder<Object, Object>();
+        HashMap<Object, Object> hashMap = new HashMap<Object, Object>();
+        hashMap.put("aaaaa", "aaaaa");
+
+        // Act
+        mapBuilder.from(hashMap);
+
+        // Assert
+        assertEquals(1, hashMap.size());
     }
 
 }

--- a/waltz-common/src/test/java/com/khartec/waltz/common/MapUtilitiesTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/MapUtilitiesTest.java
@@ -1,0 +1,158 @@
+package com.khartec.waltz.common;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+
+public class MapUtilitiesTest {
+
+  @Test
+  public void composeTest() throws Exception {
+    // Arrange
+    HashMap<Object, Object> hashMap = new HashMap<Object, Object>();
+    hashMap.put("aaaaa", "aaaaa");
+
+    // Act
+    Map<Object, Object> actual = MapUtilities.<Object, Object, Object>compose(hashMap, hashMap);
+
+    // Assert
+    assertEquals(1, actual.size());
+  }
+
+  @Test
+  public void ensureNotNullTest() throws Exception {
+    // Arrange
+    HashMap<Object, Object> hashMap = new HashMap<Object, Object>();
+    hashMap.put("aaaaa", "aaaaa");
+
+    // Act
+    Map<Object, Object> actual = MapUtilities.<Object, Object>ensureNotNull(hashMap);
+
+    // Assert
+    assertTrue(actual instanceof HashMap);
+  }
+
+  @Test
+  public void isEmptyTest() throws Exception {
+    // Arrange
+    HashMap<Object, Object> hashMap = new HashMap<Object, Object>();
+    hashMap.put("aaaaa", "aaaaa");
+
+    // Act
+    boolean actual = MapUtilities.<Object, Object>isEmpty(hashMap);
+
+    // Assert
+    assertFalse(actual);
+  }
+
+  @Test
+  public void maybeGetTest() throws Exception {
+    // Arrange
+    HashMap<Object, Object> hashMap = new HashMap<Object, Object>();
+    hashMap.put("aaaaa", "aaaaa");
+    String key = "aaaaa";
+
+    // Act
+    Optional<Object> actual = MapUtilities.<Object, Object>maybeGet(hashMap, key);
+
+    // Assert
+    assertEquals("Optional[aaaaa]", actual.toString());
+  }
+
+  @Test
+  public void newHashMapTest() throws Exception {
+    // Arrange
+    String k1 = "aaaaa";
+    String v1 = "aaaaa";
+    String k2 = "aaaaa";
+
+    // Act
+    Map<Object, Object> actual = MapUtilities.<Object, Object>newHashMap(k1, v1, k2, k1, v1, k2, k1, v1, k2, k1);
+
+    // Assert
+    assertEquals(1, actual.size());
+  }
+
+  @Test
+  public void newHashMapTest2() throws Exception {
+    // Arrange and Act
+    HashMap<Object, Object> actual = MapUtilities.<Object, Object>newHashMap();
+
+    // Assert
+    assertEquals(0, actual.size());
+  }
+
+  @Test
+  public void newHashMapTest3() throws Exception {
+    // Arrange
+    String k1 = "aaaaa";
+    String v1 = "aaaaa";
+    String k2 = "aaaaa";
+
+    // Act
+    Map<Object, Object> actual = MapUtilities.<Object, Object>newHashMap(k1, v1, k2, k1);
+
+    // Assert
+    assertEquals(1, actual.size());
+  }
+
+  @Test
+  public void newHashMapTest4() throws Exception {
+    // Arrange
+    String k1 = "aaaaa";
+    String v1 = "aaaaa";
+    String k2 = "aaaaa";
+
+    // Act
+    Map<Object, Object> actual = MapUtilities.<Object, Object>newHashMap(k1, v1, k2, k1, v1, k2, k1, v1);
+
+    // Assert
+    assertEquals(1, actual.size());
+  }
+
+  @Test
+  public void newHashMapTest5() throws Exception {
+    // Arrange
+    String k1 = "aaaaa";
+    String v1 = "aaaaa";
+    String k2 = "aaaaa";
+
+    // Act
+    Map<Object, Object> actual = MapUtilities.<Object, Object>newHashMap(k1, v1, k2, k1, v1, k2);
+
+    // Assert
+    assertEquals(1, actual.size());
+  }
+
+  @Test
+  public void newHashMapTest6() throws Exception {
+    // Arrange
+    String key = "aaaaa";
+    String val = "aaaaa";
+
+    // Act
+    Map<Object, Object> actual = MapUtilities.<Object, Object>newHashMap(key, val);
+
+    // Assert
+    assertEquals(1, actual.size());
+  }
+
+  @Test
+  public void newHashMapTest7() throws Exception {
+    // Arrange
+    String k1 = "aaaaa";
+    String v1 = "aaaaa";
+    String k2 = "aaaaa";
+
+    // Act
+    Map<Object, Object> actual = MapUtilities.<Object, Object>newHashMap(k1, v1, k2, k1, v1, k2, k1, v1, k2, k1, v1,
+        k2);
+
+    // Assert
+    assertEquals(1, actual.size());
+  }
+}

--- a/waltz-common/src/test/java/com/khartec/waltz/common/ObjectUtilitiesTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/ObjectUtilitiesTest.java
@@ -1,0 +1,32 @@
+package com.khartec.waltz.common;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ObjectUtilitiesTest {
+
+  @Test
+  public void dumpTest() throws Exception {
+    // Arrange
+    String x = "aaaaa";
+
+    // Act
+    Object actual = ObjectUtilities.<Object>dump(x);
+
+    // Assert
+    assertEquals("aaaaa", actual);
+  }
+
+  @Test
+  public void firstNotNullTest() throws Exception {
+    // Arrange
+    Object[] ts = new Object[]{"aaaaa", "aaaaa", "aaaaa"};
+
+    // Act
+    Object actual = ObjectUtilities.<Object>firstNotNull(ts);
+
+    // Assert
+    assertEquals("aaaaa", actual);
+  }
+}

--- a/waltz-common/src/test/java/com/khartec/waltz/common/OptionalUtilitiesTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/OptionalUtilitiesTest.java
@@ -1,0 +1,60 @@
+package com.khartec.waltz.common;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+
+public class OptionalUtilitiesTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void contentsEqualTest() throws Exception {
+    // Arrange
+    Optional<Object> opt = null;
+    String val = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    OptionalUtilities.<Object>contentsEqual(opt, val);
+  }
+
+  @Test
+  public void maybeTest() throws Exception {
+    // Arrange
+    String value = "aaaaa";
+
+    // Act
+    Optional<Object> actual = OptionalUtilities.<Object>maybe(value);
+
+    // Assert
+    assertEquals("Optional[aaaaa]", actual.toString());
+  }
+
+  @Test
+  public void ofNullableOptionalTest() throws Exception {
+    // Arrange
+    Optional<Object> nullable = null;
+
+    // Act
+    Optional<Object> actual = OptionalUtilities.<Object>ofNullableOptional(nullable);
+
+    // Assert
+    assertEquals("Optional.empty", actual.toString());
+  }
+
+  @Test
+  public void toListTest() throws Exception {
+    // Arrange
+    Optional<Object>[] optionals = new Optional[]{null, null, null};
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    OptionalUtilities.<Object>toList(optionals);
+  }
+}

--- a/waltz-common/src/test/java/com/khartec/waltz/common/OptionalUtilities_ofNullableOptional.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/OptionalUtilities_ofNullableOptional.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import java.util.Optional;
 
 import static com.khartec.waltz.common.OptionalUtilities.ofNullableOptional;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class OptionalUtilities_ofNullableOptional {
 

--- a/waltz-common/src/test/java/com/khartec/waltz/common/RandomUtilitiesTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/RandomUtilitiesTest.java
@@ -1,0 +1,90 @@
+package com.khartec.waltz.common;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class RandomUtilitiesTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void randomIntBetweenTest() throws Exception {
+    // Arrange
+    int lower = 1;
+    int upper = 1;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    RandomUtilities.randomIntBetween(lower, upper);
+  }
+
+  @Test
+  public void randomPickTest() throws Exception {
+    // Arrange
+    ArrayList<Object> arrayList = new ArrayList<Object>();
+    arrayList.add("aaaaa");
+    int howMany = 1;
+
+    // Act
+    List<Object> actual = RandomUtilities.<Object>randomPick(arrayList, howMany);
+
+    // Assert
+    assertEquals(1, actual.size());
+  }
+
+  @Test
+  public void randomPickTest2() throws Exception {
+    // Arrange
+    ArrayList<Object> arrayList = new ArrayList<Object>();
+    arrayList.add("aaaaa");
+
+    // Act
+    Object actual = RandomUtilities.<Object>randomPick((java.util.Collection<Object>) arrayList);
+
+    // Assert
+    assertEquals("aaaaa", actual);
+  }
+
+  @Test
+  public void randomPickTest3() throws Exception {
+    // Arrange
+    ArrayList<Object> arrayList = new ArrayList<Object>();
+    arrayList.add("aaaaa");
+
+    // Act
+    Object actual = RandomUtilities.<Object>randomPick((java.util.List<Object>) arrayList);
+
+    // Assert
+    assertEquals("aaaaa", actual);
+  }
+
+  @Test
+  public void randomPickTest4() throws Exception {
+    // Arrange
+    Object[] ts = new Object[]{"aaaaa", "aaaaa", "aaaaa"};
+
+    // Act
+    Object actual = RandomUtilities.<Object>randomPick(ts);
+
+    // Assert
+    assertEquals("aaaaa", actual);
+  }
+
+  @Test
+  public void randomlySizedIntStreamTest() throws Exception {
+    // Arrange
+    int lower = 1;
+    int upper = 1;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    RandomUtilities.randomlySizedIntStream(lower, upper);
+  }
+}

--- a/waltz-common/src/test/java/com/khartec/waltz/common/SetUtilitiesTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/SetUtilitiesTest.java
@@ -1,0 +1,132 @@
+package com.khartec.waltz.common;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class SetUtilitiesTest {
+
+  @Test
+  public void asSetTest() throws Exception {
+    // Arrange
+    Object[] ts = new Object[]{"aaaaa", "aaaaa", "aaaaa"};
+
+    // Act
+    Set<Object> actual = SetUtilities.<Object>asSet(ts);
+
+    // Assert
+    assertEquals(1, actual.size());
+  }
+
+  @Test
+  public void fromArrayTest() throws Exception {
+    // Arrange
+    Object[] ts = new Object[]{"aaaaa", "aaaaa", "aaaaa"};
+
+    // Act
+    Set<Object> actual = SetUtilities.<Object>fromArray(ts);
+
+    // Assert
+    assertEquals(1, actual.size());
+  }
+
+  @Test
+  public void fromCollectionTest() throws Exception {
+    // Arrange
+    ArrayList<Object> arrayList = new ArrayList<Object>();
+    arrayList.add("aaaaa");
+
+    // Act
+    Set<Object> actual = SetUtilities.<Object>fromCollection(arrayList);
+
+    // Assert
+    assertEquals(1, actual.size());
+  }
+
+  @Test
+  public void intersectionTest() throws Exception {
+    // Arrange
+    HashSet<Object> hashSet = new HashSet<Object>();
+    hashSet.add("aaaaa");
+    HashSet<Object> hashSet1 = new HashSet<Object>();
+    hashSet1.add("aaaaa");
+
+    // Act
+    Set<Object> actual = SetUtilities.<Object>intersection(hashSet, hashSet1);
+
+    // Assert
+    assertEquals(1, actual.size());
+  }
+
+  @Test
+  public void minusTest() throws Exception {
+    // Arrange
+    HashSet<Object> hashSet = new HashSet<Object>();
+    hashSet.add("aaaaa");
+    HashSet<Object> hashSet1 = new HashSet<Object>();
+    hashSet1.add("aaaaa");
+    Set<Object>[] yss = new Set[]{hashSet, hashSet1, hashSet};
+
+    // Act
+    Set<Object> actual = SetUtilities.<Object>minus(hashSet, yss);
+
+    // Assert
+    assertEquals(0, actual.size());
+  }
+
+  @Test
+  public void orderedUnionTest() throws Exception {
+    // Arrange
+    ArrayList<Object> arrayList = new ArrayList<Object>();
+    arrayList.add("aaaaa");
+    ArrayList<Object> arrayList1 = new ArrayList<Object>();
+    arrayList1.add("aaaaa");
+    ArrayList<Object> arrayList2 = new ArrayList<Object>();
+    arrayList2.add("aakaa");
+    Collection<Object>[] xss = new Collection[]{arrayList, arrayList1, arrayList2};
+
+    // Act
+    Set<Object> actual = SetUtilities.<Object>orderedUnion(xss);
+
+    // Assert
+    assertEquals(2, actual.size());
+  }
+
+  @Test
+  public void unionAllTest() throws Exception {
+    // Arrange
+    ArrayList<Collection<Object>> arrayList = new ArrayList<Collection<Object>>();
+    ArrayList<Object> arrayList1 = new ArrayList<Object>();
+    arrayList1.add("aaaaa");
+    arrayList.add(arrayList1);
+
+    // Act
+    Collection<Object> actual = SetUtilities.<Object>unionAll(arrayList);
+
+    // Assert
+    assertEquals(1, actual.size());
+  }
+
+  @Test
+  public void unionTest() throws Exception {
+    // Arrange
+    ArrayList<Object> arrayList = new ArrayList<Object>();
+    arrayList.add("aaaaa");
+    ArrayList<Object> arrayList1 = new ArrayList<Object>();
+    arrayList1.add("aaaaa");
+    ArrayList<Object> arrayList2 = new ArrayList<Object>();
+    arrayList2.add("aakaa");
+    Collection<Object>[] xss = new Collection[]{arrayList, arrayList1, arrayList2};
+
+    // Act
+    Set<Object> actual = SetUtilities.<Object>union(xss);
+
+    // Assert
+    assertEquals(2, actual.size());
+  }
+}

--- a/waltz-common/src/test/java/com/khartec/waltz/common/StreamUtilitiesTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/StreamUtilitiesTest.java
@@ -1,0 +1,41 @@
+package com.khartec.waltz.common;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+public class StreamUtilitiesTest {
+
+  @Test
+  public void concatTest() throws Exception {
+    // Arrange
+    ArrayList<Object> arrayList = new ArrayList<Object>();
+    arrayList.add("aaaaa");
+    ArrayList<Object> arrayList1 = new ArrayList<Object>();
+    arrayList1.add("aaaaa");
+    ArrayList<Object> arrayList2 = new ArrayList<Object>();
+    arrayList2.add("aakaa");
+    Collection<Object>[] collectionArray = new Collection[]{arrayList, arrayList1, arrayList2};
+
+    // Act
+    StreamUtilities.<Object>concat(collectionArray);
+
+    // Assert
+    assertEquals(3, collectionArray.length);
+  }
+
+  @Test
+  public void ofNullableArrayTest() throws Exception {
+    // Arrange
+    Object[] objectArray = new Object[]{"aaaaa", "aaaaa", "aaaaa"};
+
+    // Act
+    StreamUtilities.<Object>ofNullableArray(objectArray);
+
+    // Assert
+    assertEquals(3, objectArray.length);
+  }
+}

--- a/waltz-common/src/test/java/com/khartec/waltz/common/StringUtilitiesTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/StringUtilitiesTest.java
@@ -1,0 +1,200 @@
+package com.khartec.waltz.common;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+
+public class StringUtilitiesTest {
+
+  @Test
+  public void firstCharTest() throws Exception {
+    // Arrange
+    String str = "aaaaa";
+    char dflt = 'c';
+
+    // Act
+    char actual = StringUtilities.firstChar(str, dflt);
+
+    // Assert
+    assertEquals('a', actual);
+  }
+
+  @Test
+  public void ifEmptyTest() throws Exception {
+    // Arrange
+    String x = "aaaaa";
+    String defaultValue = "aaaaa";
+
+    // Act
+    String actual = StringUtilities.ifEmpty(x, defaultValue);
+
+    // Assert
+    assertEquals("aaaaa", actual);
+  }
+
+  @Test
+  public void isEmptyTest() throws Exception {
+    // Arrange
+    String x = "aaaaa";
+
+    // Act
+    boolean actual = StringUtilities.isEmpty(x);
+
+    // Assert
+    assertFalse(actual);
+  }
+
+  @Test
+  public void isEmptyTest2() throws Exception {
+    // Arrange
+    Optional<String> maybeString = null;
+
+    // Act
+    boolean actual = StringUtilities.isEmpty(maybeString);
+
+    // Assert
+    assertTrue(actual);
+  }
+
+  @Test
+  public void joinTest() throws Exception {
+    // Arrange
+    ArrayList<Object> arrayList = new ArrayList<Object>();
+    arrayList.add("aaaaa");
+    String separator = "aaaaa";
+
+    // Act
+    String actual = StringUtilities.join(arrayList, separator);
+
+    // Assert
+    assertEquals("aaaaa", actual);
+  }
+
+  @Test
+  public void lengthTest() throws Exception {
+    // Arrange
+    String str = "aaaaa";
+
+    // Act
+    int actual = StringUtilities.length(str);
+
+    // Assert
+    assertEquals(5, actual);
+  }
+
+  @Test
+  public void limitTest() throws Exception {
+    // Arrange
+    String str = "aaaaa";
+    int maxLength = 1;
+
+    // Act
+    String actual = StringUtilities.limit(str, maxLength);
+
+    // Assert
+    assertEquals("a", actual);
+  }
+
+  @Test
+  public void lowerTest() throws Exception {
+    // Arrange
+    String value = "aaaaa";
+
+    // Act
+    String actual = StringUtilities.lower(value);
+
+    // Assert
+    assertEquals("aaaaa", actual);
+  }
+
+  @Test
+  public void mkSafeTest() throws Exception {
+    // Arrange
+    String str = "aaaaa";
+
+    // Act
+    String actual = StringUtilities.mkSafe(str);
+
+    // Assert
+    assertEquals("aaaaa", actual);
+  }
+
+  @Test
+  public void notEmptyTest() throws Exception {
+    // Arrange
+    String x = "aaaaa";
+
+    // Act
+    boolean actual = StringUtilities.notEmpty(x);
+
+    // Assert
+    assertTrue(actual);
+  }
+
+  @Test
+  public void parseIntegerTest() throws Exception {
+    // Arrange
+    String value = "aaaaa";
+    Integer dflt = new Integer(1);
+
+    // Act
+    Integer actual = StringUtilities.parseInteger(value, dflt);
+
+    // Assert
+    assertEquals(Integer.valueOf(1), actual);
+  }
+
+  @Test
+  public void parseLongTest() throws Exception {
+    // Arrange
+    String value = "aaaaa";
+    Long dflt = new Long(1L);
+
+    // Act
+    Long actual = StringUtilities.parseLong(value, dflt);
+
+    // Assert
+    assertEquals(Long.valueOf(1L), actual);
+  }
+
+  @Test
+  public void toOptionalTest() throws Exception {
+    // Arrange
+    String str = "aaaaa";
+
+    // Act
+    Optional<String> actual = StringUtilities.toOptional(str);
+
+    // Assert
+    assertEquals("Optional[aaaaa]", actual.toString());
+  }
+
+  @Test
+  public void tokeniseTest() throws Exception {
+    // Arrange
+    String value = "aaaaa";
+    String regex = "aaaaa";
+
+    // Act
+    List<String> actual = StringUtilities.tokenise(value, regex);
+
+    // Assert
+    assertEquals(0, actual.size());
+  }
+
+  @Test
+  public void tokeniseTest2() throws Exception {
+    // Arrange
+    String value = "aaaaa";
+
+    // Act
+    List<String> actual = StringUtilities.tokenise(value);
+
+    // Assert
+    assertEquals(1, actual.size());
+  }
+}

--- a/waltz-common/src/test/java/com/khartec/waltz/common/SvgUtilitiesTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/SvgUtilitiesTest.java
@@ -1,0 +1,23 @@
+package com.khartec.waltz.common;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.xml.sax.SAXParseException;
+
+public class SvgUtilitiesTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void convertVisioSvgTest() throws Exception {
+    // Arrange
+    String key = "aaaaa";
+    String svgStr = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(SAXParseException.class);
+    SvgUtilities.convertVisioSvg(key, svgStr);
+  }
+}

--- a/waltz-common/src/test/java/com/khartec/waltz/common/XmlUtilitiesTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/XmlUtilitiesTest.java
@@ -1,0 +1,62 @@
+package com.khartec.waltz.common;
+
+import com.sun.org.apache.xerces.internal.dom.CoreDocumentImpl;
+import org.junit.Test;
+
+import javax.imageio.metadata.IIOMetadataNode;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class XmlUtilitiesTest {
+
+  @Test
+  public void createNonValidatingDocumentBuilderFactoryTest() throws Exception {
+    // Arrange and Act
+    DocumentBuilderFactory actual = XmlUtilities.createNonValidatingDocumentBuilderFactory();
+
+    // Assert
+    assertFalse(actual.isIgnoringComments());
+  }
+
+  @Test
+  public void printDocumentTest() throws Exception {
+    // Arrange
+    CoreDocumentImpl doc = new CoreDocumentImpl();
+    boolean prettyPrint = true;
+
+    // Act
+    String actual = XmlUtilities.printDocument(doc, prettyPrint);
+
+    // Assert
+    assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n\n", actual);
+  }
+
+  @Test
+  public void printDocumentTest2() throws Exception {
+    // Arrange
+    CoreDocumentImpl coreDocumentImpl = new CoreDocumentImpl();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    boolean prettyPrint = true;
+
+    // Act
+    XmlUtilities.printDocument(coreDocumentImpl, out, prettyPrint);
+
+    // Assert
+    assertEquals(null, coreDocumentImpl.getEncoding());
+  }
+
+  @Test
+  public void streamTest() throws Exception {
+    // Arrange
+    IIOMetadataNode iIOMetadataNode = new IIOMetadataNode();
+
+    // Act
+    XmlUtilities.stream(iIOMetadataNode);
+
+    // Assert
+    assertEquals(null, iIOMetadataNode.getLocalName());
+  }
+}

--- a/waltz-common/src/test/java/com/khartec/waltz/common/exception/DuplicateKeyExceptionTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/exception/DuplicateKeyExceptionTest.java
@@ -1,0 +1,32 @@
+package com.khartec.waltz.common.exception;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DuplicateKeyExceptionTest {
+  @Test
+  public void DuplicateKeyExceptionTest() throws Exception {
+    // Arrange
+    String message = "aaaaa";
+
+    // Act
+    DuplicateKeyException duplicateKeyException = new DuplicateKeyException(message);
+
+    // Assert
+    assertEquals("com.khartec.waltz.common.exception.DuplicateKeyException: aaaaa", duplicateKeyException.toString());
+  }
+
+  @Test
+  public void DuplicateKeyExceptionTest2() throws Exception {
+    // Arrange
+    String message = "aaaaa";
+    Throwable cause = new Throwable();
+
+    // Act
+    DuplicateKeyException duplicateKeyException = new DuplicateKeyException(message, cause);
+
+    // Assert
+    assertEquals("com.khartec.waltz.common.exception.DuplicateKeyException: aaaaa", duplicateKeyException.toString());
+  }
+}

--- a/waltz-common/src/test/java/com/khartec/waltz/common/exception/InsufficientPrivelegeExceptionTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/exception/InsufficientPrivelegeExceptionTest.java
@@ -1,0 +1,20 @@
+package com.khartec.waltz.common.exception;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class InsufficientPrivelegeExceptionTest {
+  @Test
+  public void InsufficientPrivelegeExceptionTest() throws Exception {
+    // Arrange
+    String message = "aaaaa";
+
+    // Act
+    InsufficientPrivelegeException insufficientPrivelegeException = new InsufficientPrivelegeException(message);
+
+    // Assert
+    assertEquals("com.khartec.waltz.common.exception.InsufficientPrivelegeException: aaaaa",
+        insufficientPrivelegeException.toString());
+  }
+}

--- a/waltz-common/src/test/java/com/khartec/waltz/common/hierarchy/FlatNodeTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/hierarchy/FlatNodeTest.java
@@ -1,0 +1,64 @@
+package com.khartec.waltz.common.hierarchy;
+
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class FlatNodeTest {
+  @Test
+  public void FlatNodeTest() throws Exception {
+    // Arrange
+    String id = "aaaaa";
+    Optional<Object> parentId = null;
+    String data = "aaaaa";
+
+    // Act
+    FlatNode<Object, Object> flatNode = new FlatNode<Object, Object>(id, parentId, data);
+
+    // Assert
+    Optional<Object> parentId1 = flatNode.getParentId();
+    Object data1 = flatNode.getData();
+    assertEquals(null, parentId1);
+    assertTrue(flatNode.getId() instanceof String);
+    assertTrue(data1 instanceof String);
+  }
+
+  @Test
+  public void getDataTest() throws Exception {
+    // Arrange
+    FlatNode<Object, Object> flatNode = new FlatNode<Object, Object>("aaaaa", null, "aaaaa");
+
+    // Act
+    Object actual = flatNode.getData();
+
+    // Assert
+    assertEquals("aaaaa", actual);
+  }
+
+  @Test
+  public void getIdTest() throws Exception {
+    // Arrange
+    FlatNode<Object, Object> flatNode = new FlatNode<Object, Object>("aaaaa", null, "aaaaa");
+
+    // Act
+    Object actual = flatNode.getId();
+
+    // Assert
+    assertEquals("aaaaa", actual);
+  }
+
+  @Test
+  public void getParentIdTest() throws Exception {
+    // Arrange
+    FlatNode<Object, Object> flatNode = new FlatNode<Object, Object>("aaaaa", null, "aaaaa");
+
+    // Act
+    Optional<Object> actual = flatNode.getParentId();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+}

--- a/waltz-common/src/test/java/com/khartec/waltz/common/hierarchy/ForestTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/hierarchy/ForestTest.java
@@ -1,0 +1,77 @@
+package com.khartec.waltz.common.hierarchy;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+
+public class ForestTest {
+  @Test
+  public void ForestTest() throws Exception {
+    // Arrange
+    HashMap<Object, Node<Object, Object>> hashMap = new HashMap<Object, Node<Object, Object>>();
+    String string = "aaaaa";
+    hashMap.put(string, new Node<Object, Object>("aaaaa", string));
+    HashSet<Node<Object, Object>> hashSet = new HashSet<Node<Object, Object>>();
+    hashSet.add(new Node<Object, Object>(string, "aaaaaaaaaaaaaaa"));
+
+    // Act
+    Forest<Object, Object> forest = new Forest<Object, Object>(hashMap, hashSet);
+
+    // Assert
+    assertEquals("Forest{#allNodes=1, rootNodes=[Node{id=aaaaa, #children=0}]}", forest.toString());
+  }
+
+  @Test
+  public void getAllNodesTest() throws Exception {
+    // Arrange
+    HashMap<Object, Node<Object, Object>> hashMap = new HashMap<Object, Node<Object, Object>>();
+    String string = "aaaaa";
+    hashMap.put(string, new Node<Object, Object>("aaaaa", string));
+    HashSet<Node<Object, Object>> hashSet = new HashSet<Node<Object, Object>>();
+    hashSet.add(new Node<Object, Object>("aaaaa", "aaaaa"));
+    Forest<Object, Object> forest = new Forest<Object, Object>(hashMap, hashSet);
+
+    // Act
+    forest.getAllNodes();
+
+    // Assert
+    assertEquals("Forest{#allNodes=1, rootNodes=[Node{id=aaaaa, #children=0}]}", forest.toString());
+  }
+
+  @Test
+  public void getRootNodesTest() throws Exception {
+    // Arrange
+    HashMap<Object, Node<Object, Object>> hashMap = new HashMap<Object, Node<Object, Object>>();
+    String string = "aaaaa";
+    hashMap.put(string, new Node<Object, Object>("aaaaa", string));
+    HashSet<Node<Object, Object>> hashSet = new HashSet<Node<Object, Object>>();
+    hashSet.add(new Node<Object, Object>("aaaaa", "aaaaa"));
+    Forest<Object, Object> forest = new Forest<Object, Object>(hashMap, hashSet);
+
+    // Act
+    forest.getRootNodes();
+
+    // Assert
+    assertEquals("Forest{#allNodes=1, rootNodes=[Node{id=aaaaa, #children=0}]}", forest.toString());
+  }
+
+  @Test
+  public void toStringTest() throws Exception {
+    // Arrange
+    HashMap<Object, Node<Object, Object>> hashMap = new HashMap<Object, Node<Object, Object>>();
+    String string = "aaaaa";
+    hashMap.put(string, new Node<Object, Object>("aaaaa", string));
+    HashSet<Node<Object, Object>> hashSet = new HashSet<Node<Object, Object>>();
+    hashSet.add(new Node<Object, Object>("aaaaa", "aaaaa"));
+    Forest<Object, Object> forest = new Forest<Object, Object>(hashMap, hashSet);
+
+    // Act
+    String actual = forest.toString();
+
+    // Assert
+    assertEquals("Forest{#allNodes=1, rootNodes=[Node{id=aaaaa, #children=0}]}", actual);
+  }
+}

--- a/waltz-common/src/test/java/com/khartec/waltz/common/hierarchy/HierarchyUtilitiesTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/hierarchy/HierarchyUtilitiesTest.java
@@ -1,0 +1,73 @@
+package com.khartec.waltz.common.hierarchy;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class HierarchyUtilitiesTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void assignDepthsTest() throws Exception {
+    // Arrange
+    HashMap<Object, Node<Object, Object>> hashMap = new HashMap<Object, Node<Object, Object>>();
+    String string = "aaaaa";
+    hashMap.put(string, new Node<Object, Object>("aaaaa", string));
+    HashSet<Node<Object, Object>> hashSet = new HashSet<Node<Object, Object>>();
+    hashSet.add(new Node<Object, Object>("aaaaa", "aaaaa"));
+    Forest<Object, Object> forest = new Forest<Object, Object>(hashMap, hashSet);
+
+    // Act
+    Map<Object, Integer> actual = HierarchyUtilities.<Object, Object>assignDepths(forest);
+
+    // Assert
+    assertEquals(1, actual.size());
+  }
+
+  @Test
+  public void hasCycleTest() throws Exception {
+    // Arrange
+    HashMap<Object, Node<Object, Object>> hashMap = new HashMap<Object, Node<Object, Object>>();
+    String string = "aaaaa";
+    hashMap.put(string, new Node<Object, Object>("aaaaa", string));
+    HashSet<Node<Object, Object>> hashSet = new HashSet<Node<Object, Object>>();
+    hashSet.add(new Node<Object, Object>("aaaaa", "aaaaa"));
+    Forest<Object, Object> forest = new Forest<Object, Object>(hashMap, hashSet);
+
+    // Act
+    boolean actual = HierarchyUtilities.<Object, Object>hasCycle(forest);
+
+    // Assert
+    assertFalse(actual);
+  }
+
+  @Test
+  public void parentsTest() throws Exception {
+    // Arrange
+    Node<Object, Object> startNode = new Node<Object, Object>("aaaaa", "aaaaa");
+
+    // Act
+    List<Node<Object, Object>> actual = HierarchyUtilities.<Object, Object>parents(startNode);
+
+    // Assert
+    assertEquals(0, actual.size());
+  }
+
+  @Test
+  public void toForestTest() throws Exception {
+    // Arrange
+    ArrayList<FlatNode<Object, Object>> arrayList = new ArrayList<FlatNode<Object, Object>>();
+    arrayList.add(new FlatNode<Object, Object>("aaaaa", null, "aaaaa"));
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    HierarchyUtilities.<Object, Object>toForest(arrayList);
+  }
+}

--- a/waltz-common/src/test/java/com/khartec/waltz/common/hierarchy/NodeTest.java
+++ b/waltz-common/src/test/java/com/khartec/waltz/common/hierarchy/NodeTest.java
@@ -1,0 +1,113 @@
+package com.khartec.waltz.common.hierarchy;
+
+import org.junit.Test;
+
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+public class NodeTest {
+  @Test
+  public void NodeTest() throws Exception {
+    // Arrange
+    String id = "aaaaa";
+    String data = "aaaaa";
+
+    // Act
+    Node<Object, Object> node = new Node<Object, Object>(id, data);
+
+    // Assert
+    String toStringResult = node.toString();
+    Object data1 = node.getData();
+    assertEquals("Node{id=aaaaa, #children=0}", toStringResult);
+    assertEquals(null, node.getParent());
+    assertTrue(data1 instanceof String);
+  }
+
+  @Test
+  public void addChildTest() throws Exception {
+    // Arrange
+    String string = "aaaaa";
+    String string1 = "aaaaa";
+    Node<Object, Object> node = new Node<Object, Object>(string, string1);
+    Node childNode = new Node(string, string1);
+
+    // Act
+    Node actual = node.addChild(childNode);
+
+    // Assert
+    assertEquals("Node{id=aaaaa, #children=1}", actual.toString());
+  }
+
+  @Test
+  public void getChildrenTest() throws Exception {
+    // Arrange
+    Node<Object, Object> node = new Node<Object, Object>("aaaaa", "aaaaa");
+
+    // Act
+    Set<Node<Object, Object>> actual = node.getChildren();
+
+    // Assert
+    assertEquals(0, actual.size());
+  }
+
+  @Test
+  public void getDataTest() throws Exception {
+    // Arrange
+    Node<Object, Object> node = new Node<Object, Object>("aaaaa", "aaaaa");
+
+    // Act
+    Object actual = node.getData();
+
+    // Assert
+    assertEquals("aaaaa", actual);
+  }
+
+  @Test
+  public void getIdTest() throws Exception {
+    // Arrange
+    Node<Object, Object> node = new Node<Object, Object>("aaaaa", "aaaaa");
+
+    // Act
+    Object actual = node.getId();
+
+    // Assert
+    assertEquals("aaaaa", actual);
+  }
+
+  @Test
+  public void getParentTest() throws Exception {
+    // Arrange
+    Node<Object, Object> node = new Node<Object, Object>("aaaaa", "aaaaa");
+
+    // Act
+    Node<Object, Object> actual = node.getParent();
+
+    // Assert
+    assertEquals(null, actual);
+  }
+
+  @Test
+  public void setParentTest() throws Exception {
+    // Arrange
+    Node<Object, Object> node = new Node<Object, Object>("aaaaa", "aaaaa");
+
+    // Act
+    Node actual = node.setParent(node);
+
+    // Assert
+    assertSame(actual, actual.getParent());
+  }
+
+  @Test
+  public void toStringTest() throws Exception {
+    // Arrange
+    Node<Object, Object> node = new Node<Object, Object>("aaaaa", "aaaaa");
+
+    // Act
+    String actual = node.toString();
+
+    // Assert
+    assertEquals("Node{id=aaaaa, #children=0}", actual);
+  }
+}

--- a/waltz-data/pom.xml
+++ b/waltz-data/pom.xml
@@ -60,6 +60,13 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>1.6.5</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/waltz-data/src/test/java/com/khartec/waltz/data/DBExecutorPoolTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/DBExecutorPoolTest.java
@@ -1,0 +1,15 @@
+package com.khartec.waltz.data;
+
+import org.junit.Test;
+
+public class DBExecutorPoolTest {
+  @Test
+  public void DBExecutorPoolTest() throws Exception {
+    // Arrange
+    int dbPoolMin = 1;
+    int dbPoolMax = 1;
+
+    // Act
+    new DBExecutorPool(dbPoolMin, dbPoolMax);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/EntityLifecycleStatusUtilsTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/EntityLifecycleStatusUtilsTest.java
@@ -1,0 +1,24 @@
+package com.khartec.waltz.data;
+
+import com.khartec.waltz.model.EntityLifecycleStatus;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class EntityLifecycleStatusUtilsTest {  
+  @Test
+  public void convertToIsRemovedFlagsTest() throws Exception {
+    // Arrange
+    HashSet<EntityLifecycleStatus> hashSet = new HashSet<EntityLifecycleStatus>();
+    hashSet.add(EntityLifecycleStatus.ACTIVE);
+
+    // Act
+    List<Boolean> actual = EntityLifecycleStatusUtils.convertToIsRemovedFlags(hashSet);
+
+    // Assert
+    assertEquals(2, actual.size());
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/EntityReferenceNameResolverTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/EntityReferenceNameResolverTest.java
@@ -1,0 +1,58 @@
+package com.khartec.waltz.data;
+
+import com.khartec.waltz.model.EntityReference;
+import com.khartec.waltz.model.ImmutableEntityReference;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class EntityReferenceNameResolverTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void EntityReferenceNameResolverTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new EntityReferenceNameResolver(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void resolveTest() throws Exception {
+    // Arrange
+    EntityReferenceNameResolver entityReferenceNameResolver = new EntityReferenceNameResolver(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    entityReferenceNameResolver.resolve(ref);
+  }
+
+  @Test
+  public void resolveTest2() throws Exception {
+    // Arrange
+    EntityReferenceNameResolver entityReferenceNameResolver = new EntityReferenceNameResolver(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<EntityReference> arrayList = new ArrayList<EntityReference>();
+    arrayList.add(null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    entityReferenceNameResolver.resolve(arrayList);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/GenericSelectorFactoryTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/GenericSelectorFactoryTest.java
@@ -1,0 +1,36 @@
+package com.khartec.waltz.data;
+
+import com.khartec.waltz.model.EntityKind;
+import com.khartec.waltz.model.ImmutableIdSelectionOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class GenericSelectorFactoryTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void applyForKindTest() throws Exception {
+    // Arrange
+    GenericSelectorFactory genericSelectorFactory = new GenericSelectorFactory();
+    EntityKind targetKind = EntityKind.ACTOR;
+    ImmutableIdSelectionOptions selectionOptions = null;
+
+    // Act and Assert
+    thrown.expect(UnsupportedOperationException.class);
+    genericSelectorFactory.applyForKind(targetKind, selectionOptions);
+  }
+
+  @Test
+  public void applyTest() throws Exception {
+    // Arrange
+    GenericSelectorFactory genericSelectorFactory = new GenericSelectorFactory();
+    ImmutableIdSelectionOptions selectionOptions = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    genericSelectorFactory.apply(selectionOptions);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/ImmutableGenericSelectorTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/ImmutableGenericSelectorTest.java
@@ -1,0 +1,28 @@
+package com.khartec.waltz.data;
+
+import com.khartec.waltz.data.ImmutableGenericSelector;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ImmutableGenericSelectorTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void builderTest() throws Exception {
+    // Arrange and Act
+    ImmutableGenericSelector.builder();
+  }
+
+  @Test
+  public void copyOfTest() throws Exception {
+    // Arrange
+    ImmutableGenericSelector instance = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    ImmutableGenericSelector.copyOf(instance);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/JooqUtilitiesTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/JooqUtilitiesTest.java
@@ -1,0 +1,45 @@
+package com.khartec.waltz.data;
+
+import org.jooq.SQLDialect;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+
+public class JooqUtilitiesTest {
+
+  @Test
+  public void isMariaDBTest() throws Exception {
+    // Arrange
+    SQLDialect dialect = SQLDialect.SQL99;
+
+    // Act
+    boolean actual = JooqUtilities.isMariaDB(dialect);
+
+    // Assert
+    assertFalse(actual);
+  }
+
+  @Test
+  public void isPostgresTest() throws Exception {
+    // Arrange
+    SQLDialect dialect = SQLDialect.SQL99;
+
+    // Act
+    boolean actual = JooqUtilities.isPostgres(dialect);
+
+    // Assert
+    assertFalse(actual);
+  }
+
+  @Test
+  public void isSQLServerTest() throws Exception {
+    // Arrange
+    SQLDialect dialect = SQLDialect.SQL99;
+
+    // Act
+    boolean actual = JooqUtilities.isSQLServer(dialect);
+
+    // Assert
+    assertFalse(actual);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/MSSQLTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/MSSQLTest.java
@@ -1,0 +1,47 @@
+package com.khartec.waltz.data;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class MSSQLTest {  
+  @Test
+  public void mkContainsPrefixTest() throws Exception {
+    // Arrange
+    ArrayList<String> arrayList = new ArrayList<String>();
+    arrayList.add("aaaaa");
+
+    // Act
+    JooqUtilities.MSSQL.mkContainsPrefix(arrayList);
+
+    // Assert
+    assertEquals(1, arrayList.size());
+  }
+
+  @Test
+  public void mkContainsTest() throws Exception {
+    // Arrange
+    String[] stringArray = new String[]{"aaaaa", "aaaaa", "aaaaa"};
+
+    // Act
+    JooqUtilities.MSSQL.mkContains(stringArray);
+
+    // Assert
+    assertEquals(3, stringArray.length);
+  }
+
+  @Test
+  public void mkContainsTest2() throws Exception {
+    // Arrange
+    ArrayList<String> arrayList = new ArrayList<String>();
+    arrayList.add("aaaaa");
+
+    // Act
+    JooqUtilities.MSSQL.mkContains(arrayList);
+
+    // Assert
+    assertEquals(1, arrayList.size());
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/SearchUtilitiesTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/SearchUtilitiesTest.java
@@ -1,0 +1,21 @@
+package com.khartec.waltz.data;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class SearchUtilitiesTest {  
+  @Test
+  public void mkTermsTest() throws Exception {
+    // Arrange
+    String query = "aaaaa";
+
+    // Act
+    List<String> actual = SearchUtilities.mkTerms(query);
+
+    // Assert
+    assertEquals(1, actual.size());
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/SelectorUtilitiesTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/SelectorUtilitiesTest.java
@@ -1,0 +1,32 @@
+package com.khartec.waltz.data;
+
+import com.khartec.waltz.model.ImmutableIdSelectionOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SelectorUtilitiesTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void ensureScopeIsExactTest() throws Exception {
+    // Arrange
+    ImmutableIdSelectionOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    SelectorUtilities.<com.khartec.waltz.model.IdSelectionOptions>ensureScopeIsExact(options);
+  }
+
+  @Test
+  public void mkApplicationConditionsTest() throws Exception {
+    // Arrange
+    ImmutableIdSelectionOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    SelectorUtilities.mkApplicationConditions(options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/UnsupportedSearcherTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/UnsupportedSearcherTest.java
@@ -1,0 +1,37 @@
+package com.khartec.waltz.data;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class UnsupportedSearcherTest {
+  @Test
+  public void UnsupportedSearcherTest() throws Exception {
+    // Arrange
+    SQLDialect dialect = SQLDialect.SQL99;
+
+    // Act
+    new UnsupportedSearcher<Object>(dialect);
+  }
+
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    UnsupportedSearcher<Object> unsupportedSearcher = new UnsupportedSearcher<Object>(SQLDialect.SQL99);
+    DefaultDSLContext dsl = new DefaultDSLContext(new DefaultConfiguration());
+    String terms = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act
+    List<Object> actual = unsupportedSearcher.search(dsl, terms, options);
+
+    // Assert
+    assertEquals(0, actual.size());
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/access_log/AccessLogDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/access_log/AccessLogDaoTest.java
@@ -1,0 +1,67 @@
+package com.khartec.waltz.data.access_log;
+
+import com.khartec.waltz.model.accesslog.ImmutableAccessLog;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+
+public class AccessLogDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void AccessLogDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new AccessLogDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findActiveUsersSinceTest() throws Exception {
+    // Arrange
+    AccessLogDao accessLogDao = new AccessLogDao(new DefaultDSLContext(new DefaultConfiguration()));
+    LocalDateTime dateTime = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    accessLogDao.findActiveUsersSince(dateTime);
+  }
+
+  @Test
+  public void findForUserIdTest() throws Exception {
+    // Arrange
+    AccessLogDao accessLogDao = new AccessLogDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String userId = "aaaaa";
+    Optional<Integer> limit = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    accessLogDao.findForUserId(userId, limit);
+  }
+
+  @Test
+  public void writeTest() throws Exception {
+    // Arrange
+    AccessLogDao accessLogDao = new AccessLogDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableAccessLog logEntry = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    accessLogDao.write(logEntry);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/actor/ActorDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/actor/ActorDaoTest.java
@@ -1,0 +1,87 @@
+package com.khartec.waltz.data.actor;
+
+import com.khartec.waltz.model.actor.ImmutableActorChangeCommand;
+import com.khartec.waltz.model.actor.ImmutableActorCreateCommand;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class ActorDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void ActorDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new ActorDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    ActorDao actorDao = new ActorDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableActorCreateCommand command = null;
+    String username = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    actorDao.create(command, username);
+  }
+
+  @Test
+  public void deleteIfNotUsedTest() throws Exception {
+    // Arrange
+    ActorDao actorDao = new ActorDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    actorDao.deleteIfNotUsed(id);
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    ActorDao actorDao = new ActorDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    actorDao.findAll();
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    ActorDao actorDao = new ActorDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    actorDao.getById(id);
+  }
+
+  @Test
+  public void updateTest() throws Exception {
+    // Arrange
+    ActorDao actorDao = new ActorDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableActorChangeCommand command = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    actorDao.update(command);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/actor/ActorSearchDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/actor/ActorSearchDaoTest.java
@@ -1,0 +1,44 @@
+package com.khartec.waltz.data.actor;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class ActorSearchDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void ActorSearchDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+    ActorDao actorDao = new ActorDao(defaultDSLContext);
+
+    // Act
+    new ActorSearchDao(defaultDSLContext, actorDao);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+    ActorSearchDao actorSearchDao = new ActorSearchDao(defaultDSLContext, new ActorDao(defaultDSLContext));
+    String query = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    actorSearchDao.search(query, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/allocation/AllocationDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/allocation/AllocationDaoTest.java
@@ -1,0 +1,84 @@
+package com.khartec.waltz.data.allocation;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.allocation.MeasurablePercentageChange;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class AllocationDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void AllocationDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new AllocationDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findByEntityAndSchemeTest() throws Exception {
+    // Arrange
+    AllocationDao allocationDao = new AllocationDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+    long schemeId = 1L;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    allocationDao.findByEntityAndScheme(ref, schemeId);
+  }
+
+  @Test
+  public void findByEntityTest() throws Exception {
+    // Arrange
+    AllocationDao allocationDao = new AllocationDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    allocationDao.findByEntity(ref);
+  }
+
+  @Test
+  public void findByMeasurableIdAndSchemeTest() throws Exception {
+    // Arrange
+    AllocationDao allocationDao = new AllocationDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long measurableId = 1L;
+    long schemeId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    allocationDao.findByMeasurableIdAndScheme(measurableId, schemeId);
+  }
+
+  @Test
+  public void updateAllocationsTest() throws Exception {
+    // Arrange
+    AllocationDao allocationDao = new AllocationDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+    long scheme = 1L;
+    ArrayList<MeasurablePercentageChange> arrayList = new ArrayList<MeasurablePercentageChange>();
+    arrayList.add(null);
+    String username = "aaaak";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    allocationDao.updateAllocations(ref, scheme, arrayList, username);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/allocation_scheme/AllocationSchemeDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/allocation_scheme/AllocationSchemeDaoTest.java
@@ -1,0 +1,78 @@
+package com.khartec.waltz.data.allocation_scheme;
+
+import com.khartec.waltz.model.allocation_scheme.ImmutableAllocationScheme;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class AllocationSchemeDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void AllocationSchemeDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new AllocationSchemeDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    AllocationSchemeDao allocationSchemeDao = new AllocationSchemeDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableAllocationScheme scheme = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    allocationSchemeDao.create(scheme);
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    AllocationSchemeDao allocationSchemeDao = new AllocationSchemeDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    allocationSchemeDao.findAll();
+  }
+
+  @Test
+  public void findByCategoryIdTest() throws Exception {
+    // Arrange
+    AllocationSchemeDao allocationSchemeDao = new AllocationSchemeDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long categoryId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    allocationSchemeDao.findByCategoryId(categoryId);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    AllocationSchemeDao allocationSchemeDao = new AllocationSchemeDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    allocationSchemeDao.getById(id);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/app_group/AppGroupDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/app_group/AppGroupDaoTest.java
@@ -1,0 +1,160 @@
+package com.khartec.waltz.data.app_group;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.app_group.ImmutableAppGroup;
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class AppGroupDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void AppGroupDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new AppGroupDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void deleteGroupTest() throws Exception {
+    // Arrange
+    AppGroupDao appGroupDao = new AppGroupDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long groupId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    appGroupDao.deleteGroup(groupId);
+  }
+
+  @Test
+  public void findByIdsTest() throws Exception {
+    // Arrange
+    AppGroupDao appGroupDao = new AppGroupDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String user = "aaaaa";
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    appGroupDao.findByIds(user, arrayList);
+  }
+
+  @Test
+  public void findGroupsForUserTest() throws Exception {
+    // Arrange
+    AppGroupDao appGroupDao = new AppGroupDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    appGroupDao.findGroupsForUser(userId);
+  }
+
+  @Test
+  public void findPrivateGroupsByOwnerTest() throws Exception {
+    // Arrange
+    AppGroupDao appGroupDao = new AppGroupDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    appGroupDao.findPrivateGroupsByOwner(userId);
+  }
+
+  @Test
+  public void findPublicGroupsTest() throws Exception {
+    // Arrange
+    AppGroupDao appGroupDao = new AppGroupDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    appGroupDao.findPublicGroups();
+  }
+
+  @Test
+  public void findRelatedByApplicationIdTest() throws Exception {
+    // Arrange
+    AppGroupDao appGroupDao = new AppGroupDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long appId = 1L;
+    String username = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    appGroupDao.findRelatedByApplicationId(appId, username);
+  }
+
+  @Test
+  public void findRelatedByEntityReferenceTest() throws Exception {
+    // Arrange
+    AppGroupDao appGroupDao = new AppGroupDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+    String username = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    appGroupDao.findRelatedByEntityReference(ref, username);
+  }
+
+  @Test
+  public void getGroupTest() throws Exception {
+    // Arrange
+    AppGroupDao appGroupDao = new AppGroupDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long groupId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    appGroupDao.getGroup(groupId);
+  }
+
+  @Test
+  public void insertTest() throws Exception {
+    // Arrange
+    AppGroupDao appGroupDao = new AppGroupDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableAppGroup appGroup = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    appGroupDao.insert(appGroup);
+  }
+
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    AppGroupDao appGroupDao = new AppGroupDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String query = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    appGroupDao.search(query, options);
+  }
+
+  @Test
+  public void updateTest() throws Exception {
+    // Arrange
+    AppGroupDao appGroupDao = new AppGroupDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableAppGroup appGroup = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    appGroupDao.update(appGroup);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/app_group/AppGroupEntryDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/app_group/AppGroupEntryDaoTest.java
@@ -1,0 +1,93 @@
+package com.khartec.waltz.data.app_group;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class AppGroupEntryDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void AppGroupEntryDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new AppGroupEntryDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void addApplicationTest() throws Exception {
+    // Arrange
+    AppGroupEntryDao appGroupEntryDao = new AppGroupEntryDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long groupId = 1L;
+    long applicationId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    appGroupEntryDao.addApplication(groupId, applicationId);
+  }
+
+  @Test
+  public void addApplicationsTest() throws Exception {
+    // Arrange
+    AppGroupEntryDao appGroupEntryDao = new AppGroupEntryDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long groupId = 1L;
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    appGroupEntryDao.addApplications(groupId, arrayList);
+  }
+
+  @Test
+  public void getEntriesForGroupTest() throws Exception {
+    // Arrange
+    AppGroupEntryDao appGroupEntryDao = new AppGroupEntryDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long groupId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    appGroupEntryDao.getEntriesForGroup(groupId);
+  }
+
+  @Test
+  public void removeApplicationTest() throws Exception {
+    // Arrange
+    AppGroupEntryDao appGroupEntryDao = new AppGroupEntryDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long groupId = 1L;
+    long applicationId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    appGroupEntryDao.removeApplication(groupId, applicationId);
+  }
+
+  @Test
+  public void removeApplicationsTest() throws Exception {
+    // Arrange
+    AppGroupEntryDao appGroupEntryDao = new AppGroupEntryDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long groupId = 1L;
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    appGroupEntryDao.removeApplications(groupId, arrayList);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/app_group/AppGroupMemberDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/app_group/AppGroupMemberDaoTest.java
@@ -1,0 +1,103 @@
+package com.khartec.waltz.data.app_group;
+
+import com.khartec.waltz.model.app_group.AppGroupMemberRole;
+import org.jooq.exception.DetachedException;
+import org.jooq.exception.SQLDialectNotSupportedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class AppGroupMemberDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void AppGroupMemberDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new AppGroupMemberDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void canUpdateTest() throws Exception {
+    // Arrange
+    AppGroupMemberDao appGroupMemberDao = new AppGroupMemberDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long groupId = 1L;
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    appGroupMemberDao.canUpdate(groupId, userId);
+  }
+
+  @Test
+  public void getMembersTest() throws Exception {
+    // Arrange
+    AppGroupMemberDao appGroupMemberDao = new AppGroupMemberDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long groupId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    appGroupMemberDao.getMembers(groupId);
+  }
+
+  @Test
+  public void getSubscriptionsTest() throws Exception {
+    // Arrange
+    AppGroupMemberDao appGroupMemberDao = new AppGroupMemberDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    appGroupMemberDao.getSubscriptions(userId);
+  }
+
+  @Test
+  public void registerTest() throws Exception {
+    // Arrange
+    AppGroupMemberDao appGroupMemberDao = new AppGroupMemberDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long groupId = 1L;
+    String userId = "aaaaa";
+    AppGroupMemberRole role = AppGroupMemberRole.VIEWER;
+
+    // Act and Assert
+    thrown.expect(SQLDialectNotSupportedException.class);
+    appGroupMemberDao.register(groupId, userId, role);
+  }
+
+  @Test
+  public void registerTest2() throws Exception {
+    // Arrange
+    AppGroupMemberDao appGroupMemberDao = new AppGroupMemberDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long groupId = 1L;
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(SQLDialectNotSupportedException.class);
+    appGroupMemberDao.register(groupId, userId);
+  }
+
+  @Test
+  public void unregisterTest() throws Exception {
+    // Arrange
+    AppGroupMemberDao appGroupMemberDao = new AppGroupMemberDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long groupId = 1L;
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    appGroupMemberDao.unregister(groupId, userId);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/app_group/AppGroupOrganisationalUnitDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/app_group/AppGroupOrganisationalUnitDaoTest.java
@@ -1,0 +1,68 @@
+package com.khartec.waltz.data.app_group;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class AppGroupOrganisationalUnitDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void AppGroupOrganisationalUnitDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new AppGroupOrganisationalUnitDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void addOrgUnitTest() throws Exception {
+    // Arrange
+    AppGroupOrganisationalUnitDao appGroupOrganisationalUnitDao = new AppGroupOrganisationalUnitDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long groupId = 1L;
+    long orgUnitId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    appGroupOrganisationalUnitDao.addOrgUnit(groupId, orgUnitId);
+  }
+
+  @Test
+  public void getEntriesForGroupTest() throws Exception {
+    // Arrange
+    AppGroupOrganisationalUnitDao appGroupOrganisationalUnitDao = new AppGroupOrganisationalUnitDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long groupId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    appGroupOrganisationalUnitDao.getEntriesForGroup(groupId);
+  }
+
+  @Test
+  public void removeOrgUnitTest() throws Exception {
+    // Arrange
+    AppGroupOrganisationalUnitDao appGroupOrganisationalUnitDao = new AppGroupOrganisationalUnitDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long groupId = 1L;
+    long orgUnitId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    appGroupOrganisationalUnitDao.removeOrgUnit(groupId, orgUnitId);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/application/ApplicationDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/application/ApplicationDaoTest.java
@@ -1,0 +1,121 @@
+package com.khartec.waltz.data.application;
+
+import com.khartec.waltz.model.application.ImmutableAppRegistrationRequest;
+import com.khartec.waltz.model.application.ImmutableApplication;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class ApplicationDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void ApplicationDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new ApplicationDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void countByOrganisationalUnitTest() throws Exception {
+    // Arrange
+    ApplicationDao applicationDao = new ApplicationDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    applicationDao.countByOrganisationalUnit();
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    ApplicationDao applicationDao = new ApplicationDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    applicationDao.findAll();
+  }
+
+  @Test
+  public void findByAssetCodeTest() throws Exception {
+    // Arrange
+    ApplicationDao applicationDao = new ApplicationDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String externalId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    applicationDao.findByAssetCode(externalId);
+  }
+
+  @Test
+  public void findByIdsTest() throws Exception {
+    // Arrange
+    ApplicationDao applicationDao = new ApplicationDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    applicationDao.findByIds(arrayList);
+  }
+
+  @Test
+  public void findRelatedByApplicationIdTest() throws Exception {
+    // Arrange
+    ApplicationDao applicationDao = new ApplicationDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long appId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    applicationDao.findRelatedByApplicationId(appId);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    ApplicationDao applicationDao = new ApplicationDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    applicationDao.getById(id);
+  }
+
+  @Test
+  public void registerAppTest() throws Exception {
+    // Arrange
+    ApplicationDao applicationDao = new ApplicationDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableAppRegistrationRequest request = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    applicationDao.registerApp(request);
+  }
+
+  @Test
+  public void updateTest() throws Exception {
+    // Arrange
+    ApplicationDao applicationDao = new ApplicationDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableApplication application = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    applicationDao.update(application);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/application/ApplicationIdSelectorFactoryTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/application/ApplicationIdSelectorFactoryTest.java
@@ -1,0 +1,33 @@
+package com.khartec.waltz.data.application;
+
+import com.khartec.waltz.model.ImmutableIdSelectionOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ApplicationIdSelectorFactoryTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void applyTest() throws Exception {
+    // Arrange
+    ApplicationIdSelectorFactory applicationIdSelectorFactory = new ApplicationIdSelectorFactory();
+    ImmutableIdSelectionOptions options = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    applicationIdSelectorFactory.apply(options);
+  }
+
+  @Test
+  public void mkForAppGroupTest() throws Exception {
+    // Arrange
+    ImmutableIdSelectionOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    ApplicationIdSelectorFactory.mkForAppGroup(options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/application/search/ApplicationSearchDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/application/search/ApplicationSearchDaoTest.java
@@ -1,0 +1,43 @@
+package com.khartec.waltz.data.application.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class ApplicationSearchDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void ApplicationSearchDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new ApplicationSearchDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    ApplicationSearchDao applicationSearchDao = new ApplicationSearchDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    String terms = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    applicationSearchDao.search(terms, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/application/search/MariaAppSearchTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/application/search/MariaAppSearchTest.java
@@ -1,0 +1,27 @@
+package com.khartec.waltz.data.application.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class MariaAppSearchTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    MariaAppSearch mariaAppSearch = new MariaAppSearch();
+    DefaultDSLContext dsl = new DefaultDSLContext(new DefaultConfiguration());
+    String terms = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    mariaAppSearch.search(dsl, terms, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/application/search/PostgresAppSearchTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/application/search/PostgresAppSearchTest.java
@@ -1,0 +1,27 @@
+package com.khartec.waltz.data.application.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class PostgresAppSearchTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    PostgresAppSearch postgresAppSearch = new PostgresAppSearch();
+    DefaultDSLContext dsl = new DefaultDSLContext(new DefaultConfiguration());
+    String terms = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    postgresAppSearch.search(dsl, terms, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/application/search/SqlServerAppSearchTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/application/search/SqlServerAppSearchTest.java
@@ -1,0 +1,27 @@
+package com.khartec.waltz.data.application.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SqlServerAppSearchTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    SqlServerAppSearch sqlServerAppSearch = new SqlServerAppSearch();
+    DefaultDSLContext dsl = new DefaultDSLContext(new DefaultConfiguration());
+    String query = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    sqlServerAppSearch.search(dsl, query, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/assessment_definition/AssessmentDefinitionDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/assessment_definition/AssessmentDefinitionDaoTest.java
@@ -1,0 +1,66 @@
+package com.khartec.waltz.data.assessment_definition;
+
+import com.khartec.waltz.model.EntityKind;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class AssessmentDefinitionDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void AssessmentDefinitionDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new AssessmentDefinitionDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    AssessmentDefinitionDao assessmentDefinitionDao = new AssessmentDefinitionDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    assessmentDefinitionDao.findAll();
+  }
+
+  @Test
+  public void findByEntityKindTest() throws Exception {
+    // Arrange
+    AssessmentDefinitionDao assessmentDefinitionDao = new AssessmentDefinitionDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    EntityKind kind = EntityKind.ACTOR;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    assessmentDefinitionDao.findByEntityKind(kind);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    AssessmentDefinitionDao assessmentDefinitionDao = new AssessmentDefinitionDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    assessmentDefinitionDao.getById(id);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/assessment_rating/AssessmentRatingDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/assessment_rating/AssessmentRatingDaoTest.java
@@ -1,0 +1,93 @@
+package com.khartec.waltz.data.assessment_rating;
+
+import com.khartec.waltz.data.ImmutableGenericSelector;
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.assessment_rating.ImmutableRemoveAssessmentRatingCommand;
+import com.khartec.waltz.model.assessment_rating.ImmutableSaveAssessmentRatingCommand;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class AssessmentRatingDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void AssessmentRatingDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new AssessmentRatingDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    AssessmentRatingDao assessmentRatingDao = new AssessmentRatingDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableSaveAssessmentRatingCommand command = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    assessmentRatingDao.create(command);
+  }
+
+  @Test
+  public void findByGenericSelectorTest() throws Exception {
+    // Arrange
+    AssessmentRatingDao assessmentRatingDao = new AssessmentRatingDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableGenericSelector genericSelector = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    assessmentRatingDao.findByGenericSelector(genericSelector);
+  }
+
+  @Test
+  public void findForEntityTest() throws Exception {
+    // Arrange
+    AssessmentRatingDao assessmentRatingDao = new AssessmentRatingDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    assessmentRatingDao.findForEntity(ref);
+  }
+
+  @Test
+  public void removeTest() throws Exception {
+    // Arrange
+    AssessmentRatingDao assessmentRatingDao = new AssessmentRatingDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableRemoveAssessmentRatingCommand rating = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    assessmentRatingDao.remove(rating);
+  }
+
+  @Test
+  public void updateTest() throws Exception {
+    // Arrange
+    AssessmentRatingDao assessmentRatingDao = new AssessmentRatingDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableSaveAssessmentRatingCommand command = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    assessmentRatingDao.update(command);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/asset_cost/AssetCostDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/asset_cost/AssetCostDaoTest.java
@@ -1,0 +1,62 @@
+package com.khartec.waltz.data.asset_cost;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class AssetCostDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void AssetCostDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new AssetCostDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findByAppIdTest() throws Exception {
+    // Arrange
+    AssetCostDao assetCostDao = new AssetCostDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long appId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    assetCostDao.findByAppId(appId);
+  }
+
+  @Test
+  public void findByAssetCodeTest() throws Exception {
+    // Arrange
+    AssetCostDao assetCostDao = new AssetCostDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String code = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    assetCostDao.findByAssetCode(code);
+  }
+
+  @Test
+  public void findLatestYearTest() throws Exception {
+    // Arrange
+    AssetCostDao assetCostDao = new AssetCostDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    assetCostDao.findLatestYear();
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/asset_cost/AssetCostStatsDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/asset_cost/AssetCostStatsDaoTest.java
@@ -1,0 +1,23 @@
+package com.khartec.waltz.data.asset_cost;
+
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class AssetCostStatsDaoTest {
+  @Test
+  public void AssetCostStatsDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new AssetCostStatsDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/attestation/AttestationInstanceDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/attestation/AttestationInstanceDaoTest.java
@@ -1,0 +1,147 @@
+package com.khartec.waltz.data.attestation;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.attestation.ImmutableAttestEntityCommand;
+import com.khartec.waltz.model.attestation.ImmutableAttestationInstance;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.time.LocalDateTime;
+
+import static org.junit.Assert.assertEquals;
+
+public class AttestationInstanceDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void AttestationInstanceDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new AttestationInstanceDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void attestInstanceTest() throws Exception {
+    // Arrange
+    AttestationInstanceDao attestationInstanceDao = new AttestationInstanceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long instanceId = 1L;
+    String attestedBy = "aaaaa";
+    LocalDateTime dateTime = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    attestationInstanceDao.attestInstance(instanceId, attestedBy, dateTime);
+  }
+
+  @Test
+  public void cleanupOrphansTest() throws Exception {
+    // Arrange
+    AttestationInstanceDao attestationInstanceDao = new AttestationInstanceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    attestationInstanceDao.cleanupOrphans();
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    AttestationInstanceDao attestationInstanceDao = new AttestationInstanceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableAttestationInstance attestationInstance = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    attestationInstanceDao.create(attestationInstance);
+  }
+
+  @Test
+  public void findByEntityReferenceTest() throws Exception {
+    // Arrange
+    AttestationInstanceDao attestationInstanceDao = new AttestationInstanceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    attestationInstanceDao.findByEntityReference(ref);
+  }
+
+  @Test
+  public void findByRecipientTest() throws Exception {
+    // Arrange
+    AttestationInstanceDao attestationInstanceDao = new AttestationInstanceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    String userId = "aaaaa";
+    boolean unattestedOnly = true;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    attestationInstanceDao.findByRecipient(userId, unattestedOnly);
+  }
+
+  @Test
+  public void findByRunIdTest() throws Exception {
+    // Arrange
+    AttestationInstanceDao attestationInstanceDao = new AttestationInstanceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long runId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    attestationInstanceDao.findByRunId(runId);
+  }
+
+  @Test
+  public void findForEntityByRecipientTest() throws Exception {
+    // Arrange
+    AttestationInstanceDao attestationInstanceDao = new AttestationInstanceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableAttestEntityCommand command = null;
+    String userId = "aaaaa";
+    boolean unattestedOnly = true;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    attestationInstanceDao.findForEntityByRecipient(command, userId, unattestedOnly);
+  }
+
+  @Test
+  public void findHistoricalForPendingByUserIdTest() throws Exception {
+    // Arrange
+    AttestationInstanceDao attestationInstanceDao = new AttestationInstanceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    attestationInstanceDao.findHistoricalForPendingByUserId(userId);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    AttestationInstanceDao attestationInstanceDao = new AttestationInstanceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    attestationInstanceDao.getById(id);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/attestation/AttestationInstanceRecipientDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/attestation/AttestationInstanceRecipientDaoTest.java
@@ -1,0 +1,55 @@
+package com.khartec.waltz.data.attestation;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class AttestationInstanceRecipientDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void AttestationInstanceRecipientDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new AttestationInstanceRecipientDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    AttestationInstanceRecipientDao attestationInstanceRecipientDao = new AttestationInstanceRecipientDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long instanceId = 1L;
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    attestationInstanceRecipientDao.create(instanceId, userId);
+  }
+
+  @Test
+  public void findRecipientsByRunIdTest() throws Exception {
+    // Arrange
+    AttestationInstanceRecipientDao attestationInstanceRecipientDao = new AttestationInstanceRecipientDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    Long id = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    attestationInstanceRecipientDao.findRecipientsByRunId(id);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/attestation/AttestationRunDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/attestation/AttestationRunDaoTest.java
@@ -1,0 +1,97 @@
+package com.khartec.waltz.data.attestation;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.attestation.ImmutableAttestationRunCreateCommand;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class AttestationRunDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void AttestationRunDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new AttestationRunDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    AttestationRunDao attestationRunDao = new AttestationRunDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String userId = "aaaaa";
+    ImmutableAttestationRunCreateCommand command = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    attestationRunDao.create(userId, command);
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    AttestationRunDao attestationRunDao = new AttestationRunDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    attestationRunDao.findAll();
+  }
+
+  @Test
+  public void findByEntityReferenceTest() throws Exception {
+    // Arrange
+    AttestationRunDao attestationRunDao = new AttestationRunDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    attestationRunDao.findByEntityReference(ref);
+  }
+
+  @Test
+  public void findByRecipientTest() throws Exception {
+    // Arrange
+    AttestationRunDao attestationRunDao = new AttestationRunDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    attestationRunDao.findByRecipient(userId);
+  }
+
+  @Test
+  public void findResponseSummariesTest() throws Exception {
+    // Arrange
+    AttestationRunDao attestationRunDao = new AttestationRunDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    attestationRunDao.findResponseSummaries();
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    AttestationRunDao attestationRunDao = new AttestationRunDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long attestationRunId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    attestationRunDao.getById(attestationRunId);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/attribute_change/AttributeChangeDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/attribute_change/AttributeChangeDaoTest.java
@@ -1,0 +1,52 @@
+package com.khartec.waltz.data.attribute_change;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class AttributeChangeDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void AttributeChangeDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new AttributeChangeDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findByChangeUnitIdTest() throws Exception {
+    // Arrange
+    AttributeChangeDao attributeChangeDao = new AttributeChangeDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    attributeChangeDao.findByChangeUnitId(id);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    AttributeChangeDao attributeChangeDao = new AttributeChangeDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    attributeChangeDao.getById(id);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/authoritative_source/AuthoritativeSourceDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/authoritative_source/AuthoritativeSourceDaoTest.java
@@ -1,0 +1,181 @@
+package com.khartec.waltz.data.authoritative_source;
+
+import com.khartec.waltz.model.EntityKind;
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.authoritativesource.ImmutableAuthoritativeSourceCreateCommand;
+import com.khartec.waltz.model.authoritativesource.ImmutableAuthoritativeSourceUpdateCommand;
+import org.jooq.Condition;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.powermock.reflect.Whitebox;
+
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+
+public class AuthoritativeSourceDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void AuthoritativeSourceDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new AuthoritativeSourceDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void cleanupOrphansTest() throws Exception {
+    // Arrange
+    AuthoritativeSourceDao authoritativeSourceDao = new AuthoritativeSourceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    authoritativeSourceDao.cleanupOrphans();
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    AuthoritativeSourceDao authoritativeSourceDao = new AuthoritativeSourceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    authoritativeSourceDao.findAll();
+  }
+
+  @Test
+  public void findAuthSourcesTest() throws Exception {
+    // Arrange
+    AuthoritativeSourceDao authoritativeSourceDao = new AuthoritativeSourceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    Condition customSelectionCriteria = Whitebox.newInstance(Condition.class);
+
+    // Act and Assert
+    thrown.expect(ClassCastException.class);
+    authoritativeSourceDao.findAuthSources(customSelectionCriteria);
+  }
+
+  @Test
+  public void findAuthoritativeRatingVantagePointsTest() throws Exception {
+    // Arrange
+    AuthoritativeSourceDao authoritativeSourceDao = new AuthoritativeSourceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    HashSet<Long> hashSet = new HashSet<Long>();
+    hashSet.add(new Long(1L));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    authoritativeSourceDao.findAuthoritativeRatingVantagePoints(hashSet);
+  }
+
+  @Test
+  public void findByApplicationIdTest() throws Exception {
+    // Arrange
+    AuthoritativeSourceDao authoritativeSourceDao = new AuthoritativeSourceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long applicationId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    authoritativeSourceDao.findByApplicationId(applicationId);
+  }
+
+  @Test
+  public void findByEntityKindTest() throws Exception {
+    // Arrange
+    AuthoritativeSourceDao authoritativeSourceDao = new AuthoritativeSourceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    EntityKind kind = EntityKind.ACTOR;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    authoritativeSourceDao.findByEntityKind(kind);
+  }
+
+  @Test
+  public void findByEntityReferenceTest() throws Exception {
+    // Arrange
+    AuthoritativeSourceDao authoritativeSourceDao = new AuthoritativeSourceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    authoritativeSourceDao.findByEntityReference(ref);
+  }
+
+  @Test
+  public void findNonAuthSourcesTest() throws Exception {
+    // Arrange
+    AuthoritativeSourceDao authoritativeSourceDao = new AuthoritativeSourceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    Condition customSelectionCriteria = Whitebox.newInstance(Condition.class);
+
+    // Act and Assert
+    thrown.expect(ClassCastException.class);
+    authoritativeSourceDao.findNonAuthSources(customSelectionCriteria);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    AuthoritativeSourceDao authoritativeSourceDao = new AuthoritativeSourceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    authoritativeSourceDao.getById(id);
+  }
+
+  @Test
+  public void insertTest() throws Exception {
+    // Arrange
+    AuthoritativeSourceDao authoritativeSourceDao = new AuthoritativeSourceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableAuthoritativeSourceCreateCommand command = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    authoritativeSourceDao.insert(command);
+  }
+
+  @Test
+  public void removeTest() throws Exception {
+    // Arrange
+    AuthoritativeSourceDao authoritativeSourceDao = new AuthoritativeSourceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    authoritativeSourceDao.remove(id);
+  }
+
+  @Test
+  public void updateTest() throws Exception {
+    // Arrange
+    AuthoritativeSourceDao authoritativeSourceDao = new AuthoritativeSourceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableAuthoritativeSourceUpdateCommand command = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    authoritativeSourceDao.update(command);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/bookmark/BookmarkDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/bookmark/BookmarkDaoTest.java
@@ -1,0 +1,111 @@
+package com.khartec.waltz.data.bookmark;
+
+import com.khartec.waltz.data.ImmutableGenericSelector;
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.bookmark.ImmutableBookmark;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class BookmarkDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void BookmarkDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext dsl = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    BookmarkDao bookmarkDao = new BookmarkDao(dsl);
+
+    // Assert
+    assertEquals("BookmarkDao{}", bookmarkDao.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    BookmarkDao bookmarkDao = new BookmarkDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableBookmark bookmark = null;
+    String username = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    bookmarkDao.create(bookmark, username);
+  }
+
+  @Test
+  public void deleteByIdTest() throws Exception {
+    // Arrange
+    BookmarkDao bookmarkDao = new BookmarkDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    bookmarkDao.deleteById(id);
+  }
+
+  @Test
+  public void deleteByParentSelectorTest() throws Exception {
+    // Arrange
+    BookmarkDao bookmarkDao = new BookmarkDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableGenericSelector parentRefSelector = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    bookmarkDao.deleteByParentSelector(parentRefSelector);
+  }
+
+  @Test
+  public void findByReferenceTest() throws Exception {
+    // Arrange
+    BookmarkDao bookmarkDao = new BookmarkDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference reference = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    bookmarkDao.findByReference(reference);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    BookmarkDao bookmarkDao = new BookmarkDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long bookmarkId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    bookmarkDao.getById(bookmarkId);
+  }
+
+  @Test
+  public void toStringTest() throws Exception {
+    // Arrange
+    BookmarkDao bookmarkDao = new BookmarkDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act
+    String actual = bookmarkDao.toString();
+
+    // Assert
+    assertEquals("BookmarkDao{}", actual);
+  }
+
+  @Test
+  public void updateTest() throws Exception {
+    // Arrange
+    BookmarkDao bookmarkDao = new BookmarkDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableBookmark bookmark = null;
+    String username = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    bookmarkDao.update(bookmark, username);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/bookmark/BookmarkIdSelectorFactoryTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/bookmark/BookmarkIdSelectorFactoryTest.java
@@ -1,0 +1,23 @@
+package com.khartec.waltz.data.bookmark;
+
+import com.khartec.waltz.model.ImmutableIdSelectionOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class BookmarkIdSelectorFactoryTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void applyTest() throws Exception {
+    // Arrange
+    BookmarkIdSelectorFactory bookmarkIdSelectorFactory = new BookmarkIdSelectorFactory();
+    ImmutableIdSelectionOptions selectionOptions = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    bookmarkIdSelectorFactory.apply(selectionOptions);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/change_initiative/ChangeInitiativeDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/change_initiative/ChangeInitiativeDaoTest.java
@@ -1,0 +1,54 @@
+package com.khartec.waltz.data.change_initiative;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class ChangeInitiativeDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void ChangeInitiativeDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new ChangeInitiativeDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findByExternalIdTest() throws Exception {
+    // Arrange
+    ChangeInitiativeDao changeInitiativeDao = new ChangeInitiativeDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    String externalId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    changeInitiativeDao.findByExternalId(externalId);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    ChangeInitiativeDao changeInitiativeDao = new ChangeInitiativeDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    Long id = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    changeInitiativeDao.getById(id);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/change_initiative/ChangeInitiativeIdSelectorFactoryTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/change_initiative/ChangeInitiativeIdSelectorFactoryTest.java
@@ -1,0 +1,23 @@
+package com.khartec.waltz.data.change_initiative;
+
+import com.khartec.waltz.model.ImmutableIdSelectionOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ChangeInitiativeIdSelectorFactoryTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void mkForOptionsTest() throws Exception {
+    // Arrange
+    ChangeInitiativeIdSelectorFactory changeInitiativeIdSelectorFactory = new ChangeInitiativeIdSelectorFactory();
+    ImmutableIdSelectionOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    changeInitiativeIdSelectorFactory.mkForOptions(options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/change_initiative/search/ChangeInitiativeSearchDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/change_initiative/search/ChangeInitiativeSearchDaoTest.java
@@ -1,0 +1,42 @@
+package com.khartec.waltz.data.change_initiative.search;
+
+import com.khartec.waltz.model.change_initiative.ChangeInitiative;
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ChangeInitiativeSearchDaoTest {
+  @Test
+  public void ChangeInitiativeSearchDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new ChangeInitiativeSearchDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    ChangeInitiativeSearchDao changeInitiativeSearchDao = new ChangeInitiativeSearchDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    String terms = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act
+    List<ChangeInitiative> actual = changeInitiativeSearchDao.search(terms, options);
+
+    // Assert
+    assertEquals(0, actual.size());
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/change_initiative/search/MariaChangeInitiativeSearchTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/change_initiative/search/MariaChangeInitiativeSearchTest.java
@@ -1,0 +1,27 @@
+package com.khartec.waltz.data.change_initiative.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class MariaChangeInitiativeSearchTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    MariaChangeInitiativeSearch mariaChangeInitiativeSearch = new MariaChangeInitiativeSearch();
+    DefaultDSLContext dsl = new DefaultDSLContext(new DefaultConfiguration());
+    String terms = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    mariaChangeInitiativeSearch.search(dsl, terms, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/change_initiative/search/PostgresChangeInitiativeSearchTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/change_initiative/search/PostgresChangeInitiativeSearchTest.java
@@ -1,0 +1,27 @@
+package com.khartec.waltz.data.change_initiative.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class PostgresChangeInitiativeSearchTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    PostgresChangeInitiativeSearch postgresChangeInitiativeSearch = new PostgresChangeInitiativeSearch();
+    DefaultDSLContext dsl = new DefaultDSLContext(new DefaultConfiguration());
+    String terms = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    postgresChangeInitiativeSearch.search(dsl, terms, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/change_initiative/search/SqlServerChangeInitiativeSearchTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/change_initiative/search/SqlServerChangeInitiativeSearchTest.java
@@ -1,0 +1,27 @@
+package com.khartec.waltz.data.change_initiative.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SqlServerChangeInitiativeSearchTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    SqlServerChangeInitiativeSearch sqlServerChangeInitiativeSearch = new SqlServerChangeInitiativeSearch();
+    DefaultDSLContext dsl = new DefaultDSLContext(new DefaultConfiguration());
+    String query = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    sqlServerChangeInitiativeSearch.search(dsl, query, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/change_set/ChangeSetDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/change_set/ChangeSetDaoTest.java
@@ -1,0 +1,64 @@
+package com.khartec.waltz.data.change_set;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class ChangeSetDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void ChangeSetDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new ChangeSetDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findByParentRefTest() throws Exception {
+    // Arrange
+    ChangeSetDao changeSetDao = new ChangeSetDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    changeSetDao.findByParentRef(ref);
+  }
+
+  @Test
+  public void findByPersonTest() throws Exception {
+    // Arrange
+    ChangeSetDao changeSetDao = new ChangeSetDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String employeeId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    changeSetDao.findByPerson(employeeId);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    ChangeSetDao changeSetDao = new ChangeSetDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    changeSetDao.getById(id);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/change_set/ChangeSetIdSelectorFactoryTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/change_set/ChangeSetIdSelectorFactoryTest.java
@@ -1,0 +1,23 @@
+package com.khartec.waltz.data.change_set;
+
+import com.khartec.waltz.model.ImmutableIdSelectionOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ChangeSetIdSelectorFactoryTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void applyTest() throws Exception {
+    // Arrange
+    ChangeSetIdSelectorFactory changeSetIdSelectorFactory = new ChangeSetIdSelectorFactory();
+    ImmutableIdSelectionOptions options = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    changeSetIdSelectorFactory.apply(options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/change_unit/ChangeUnitDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/change_unit/ChangeUnitDaoTest.java
@@ -1,0 +1,76 @@
+package com.khartec.waltz.data.change_unit;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.change_unit.ImmutableUpdateExecutionStatusCommand;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class ChangeUnitDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void ChangeUnitDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new ChangeUnitDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findByChangeSetIdTest() throws Exception {
+    // Arrange
+    ChangeUnitDao changeUnitDao = new ChangeUnitDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    changeUnitDao.findByChangeSetId(id);
+  }
+
+  @Test
+  public void findBySubjectRefTest() throws Exception {
+    // Arrange
+    ChangeUnitDao changeUnitDao = new ChangeUnitDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    changeUnitDao.findBySubjectRef(ref);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    ChangeUnitDao changeUnitDao = new ChangeUnitDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    changeUnitDao.getById(id);
+  }
+
+  @Test
+  public void updateExecutionStatusTest() throws Exception {
+    // Arrange
+    ChangeUnitDao changeUnitDao = new ChangeUnitDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableUpdateExecutionStatusCommand command = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    changeUnitDao.updateExecutionStatus(command);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/change_unit/ChangeUnitIdSelectorFactoryTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/change_unit/ChangeUnitIdSelectorFactoryTest.java
@@ -1,0 +1,23 @@
+package com.khartec.waltz.data.change_unit;
+
+import com.khartec.waltz.model.ImmutableIdSelectionOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ChangeUnitIdSelectorFactoryTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void applyTest() throws Exception {
+    // Arrange
+    ChangeUnitIdSelectorFactory changeUnitIdSelectorFactory = new ChangeUnitIdSelectorFactory();
+    ImmutableIdSelectionOptions options = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    changeUnitIdSelectorFactory.apply(options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/changelog/ChangeLogDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/changelog/ChangeLogDaoTest.java
@@ -1,0 +1,132 @@
+package com.khartec.waltz.data.changelog;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.changelog.ChangeLog;
+import com.khartec.waltz.model.changelog.ImmutableChangeLog;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+public class ChangeLogDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void ChangeLogDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext dsl = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new ChangeLogDao(dsl);
+  }
+
+  @Test
+  public void findByParentReferenceTest() throws Exception {
+    // Arrange
+    ChangeLogDao changeLogDao = new ChangeLogDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+    Optional<Integer> limit = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    changeLogDao.findByParentReference(ref, limit);
+  }
+
+  @Test
+  public void findByPersonReferenceTest() throws Exception {
+    // Arrange
+    ChangeLogDao changeLogDao = new ChangeLogDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+    Optional<Integer> limit = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    changeLogDao.findByPersonReference(ref, limit);
+  }
+
+  @Test
+  public void findByUserTest() throws Exception {
+    // Arrange
+    ChangeLogDao changeLogDao = new ChangeLogDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String userName = "aaaaa";
+    Optional<Integer> limit = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    changeLogDao.findByUser(userName, limit);
+  }
+
+  @Test
+  public void getContributionLeaderBoardLastMonthTest() throws Exception {
+    // Arrange
+    ChangeLogDao changeLogDao = new ChangeLogDao(new DefaultDSLContext(new DefaultConfiguration()));
+    int limit = 1;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    changeLogDao.getContributionLeaderBoardLastMonth(limit);
+  }
+
+  @Test
+  public void getContributionLeaderBoardTest() throws Exception {
+    // Arrange
+    ChangeLogDao changeLogDao = new ChangeLogDao(new DefaultDSLContext(new DefaultConfiguration()));
+    int limit = 1;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    changeLogDao.getContributionLeaderBoard(limit);
+  }
+
+  @Test
+  public void getContributionScoresForUsersTest() throws Exception {
+    // Arrange
+    ChangeLogDao changeLogDao = new ChangeLogDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<String> arrayList = new ArrayList<String>();
+    arrayList.add("aaaaa");
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    changeLogDao.getContributionScoresForUsers(arrayList);
+  }
+
+  @Test
+  public void getRankingOfContributorsTest() throws Exception {
+    // Arrange
+    ChangeLogDao changeLogDao = new ChangeLogDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    changeLogDao.getRankingOfContributors();
+  }
+
+  @Test
+  public void writeTest() throws Exception {
+    // Arrange
+    ChangeLogDao changeLogDao = new ChangeLogDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<ChangeLog> arrayList = new ArrayList<ChangeLog>();
+    arrayList.add(null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    changeLogDao.write(arrayList);
+  }
+
+  @Test
+  public void writeTest2() throws Exception {
+    // Arrange
+    ChangeLogDao changeLogDao = new ChangeLogDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableChangeLog changeLog = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    changeLogDao.write(changeLog);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/client_cache_key/ClientCacheKeyDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/client_cache_key/ClientCacheKeyDaoTest.java
@@ -1,0 +1,64 @@
+package com.khartec.waltz.data.client_cache_key;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.exception.SQLDialectNotSupportedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class ClientCacheKeyDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void ClientCacheKeyDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new ClientCacheKeyDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createOrUpdateTest() throws Exception {
+    // Arrange
+    ClientCacheKeyDao clientCacheKeyDao = new ClientCacheKeyDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String key = "aaaaa";
+    String guid = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(SQLDialectNotSupportedException.class);
+    clientCacheKeyDao.createOrUpdate(key, guid);
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    ClientCacheKeyDao clientCacheKeyDao = new ClientCacheKeyDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    clientCacheKeyDao.findAll();
+  }
+
+  @Test
+  public void getByKeyTest() throws Exception {
+    // Arrange
+    ClientCacheKeyDao clientCacheKeyDao = new ClientCacheKeyDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String key = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    clientCacheKeyDao.getByKey(key);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/complexity/ComplexityScoreDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/complexity/ComplexityScoreDaoTest.java
@@ -1,0 +1,68 @@
+package com.khartec.waltz.data.complexity;
+
+import com.khartec.waltz.schema.tables.records.ComplexityScoreRecord;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class ComplexityScoreDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void ComplexityScoreDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new ComplexityScoreDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void bulkInsertTest() throws Exception {
+    // Arrange
+    ComplexityScoreDao complexityScoreDao = new ComplexityScoreDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<ComplexityScoreRecord> arrayList = new ArrayList<ComplexityScoreRecord>();
+    arrayList.add(new ComplexityScoreRecord());
+
+    // Act
+    int[] actual = complexityScoreDao.bulkInsert(arrayList);
+
+    // Assert
+    assertEquals(0, actual.length);
+  }
+
+  @Test
+  public void deleteAllTest() throws Exception {
+    // Arrange
+    ComplexityScoreDao complexityScoreDao = new ComplexityScoreDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    complexityScoreDao.deleteAll();
+  }
+
+  @Test
+  public void getForAppTest() throws Exception {
+    // Arrange
+    ComplexityScoreDao complexityScoreDao = new ComplexityScoreDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long appId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    complexityScoreDao.getForApp(appId);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/complexity/ConnectionComplexityDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/complexity/ConnectionComplexityDaoTest.java
@@ -1,0 +1,77 @@
+package com.khartec.waltz.data.complexity;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConnectionComplexityDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void ConnectionComplexityDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new ConnectionComplexityDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void calculateBaselineTest() throws Exception {
+    // Arrange
+    ConnectionComplexityDao connectionComplexityDao = new ConnectionComplexityDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    Long appIds = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    connectionComplexityDao.calculateBaseline(appIds);
+  }
+
+  @Test
+  public void calculateBaselineTest2() throws Exception {
+    // Arrange
+    ConnectionComplexityDao connectionComplexityDao = new ConnectionComplexityDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    connectionComplexityDao.calculateBaseline();
+  }
+
+  @Test
+  public void findCountsTest() throws Exception {
+    // Arrange
+    ConnectionComplexityDao connectionComplexityDao = new ConnectionComplexityDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    Long resultLong = new Long(1L);
+    Long[] appIds = new Long[]{resultLong, new Long(1L), resultLong};
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    connectionComplexityDao.findCounts(appIds);
+  }
+
+  @Test
+  public void findCountsTest2() throws Exception {
+    // Arrange
+    ConnectionComplexityDao connectionComplexityDao = new ConnectionComplexityDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    connectionComplexityDao.findCounts();
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/complexity/MeasurableComplexityDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/complexity/MeasurableComplexityDaoTest.java
@@ -1,0 +1,41 @@
+package com.khartec.waltz.data.complexity;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class MeasurableComplexityDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void MeasurableComplexityDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new MeasurableComplexityDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void calculateBaselineTest() throws Exception {
+    // Arrange
+    MeasurableComplexityDao measurableComplexityDao = new MeasurableComplexityDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    measurableComplexityDao.calculateBaseline();
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/complexity/ServerComplexityDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/complexity/ServerComplexityDaoTest.java
@@ -1,0 +1,64 @@
+package com.khartec.waltz.data.complexity;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class ServerComplexityDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void ServerComplexityDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new ServerComplexityDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void calculateBaselineTest() throws Exception {
+    // Arrange
+    ServerComplexityDao serverComplexityDao = new ServerComplexityDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    serverComplexityDao.calculateBaseline();
+  }
+
+  @Test
+  public void findCountsByAssetCodesTest() throws Exception {
+    // Arrange
+    ServerComplexityDao serverComplexityDao = new ServerComplexityDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    String[] assetCodes = new String[]{"aaaaa", "aaaaa", "kaaaa"};
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    serverComplexityDao.findCountsByAssetCodes(assetCodes);
+  }
+
+  @Test
+  public void findCountsTest() throws Exception {
+    // Arrange
+    ServerComplexityDao serverComplexityDao = new ServerComplexityDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    serverComplexityDao.findCounts();
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/data_flow_decorator/LogicalFlowDecoratorDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/data_flow_decorator/LogicalFlowDecoratorDaoTest.java
@@ -1,0 +1,168 @@
+package com.khartec.waltz.data.data_flow_decorator;
+
+import com.khartec.waltz.model.EntityKind;
+import com.khartec.waltz.model.EntityReference;
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.data_flow_decorator.LogicalFlowDecorator;
+import com.khartec.waltz.model.rating.AuthoritativenessRating;
+import org.jooq.Condition;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.powermock.reflect.Whitebox;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+
+public class LogicalFlowDecoratorDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void LogicalFlowDecoratorDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new LogicalFlowDecoratorDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void addDecoratorsTest() throws Exception {
+    // Arrange
+    LogicalFlowDecoratorDao logicalFlowDecoratorDao = new LogicalFlowDecoratorDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<LogicalFlowDecorator> arrayList = new ArrayList<LogicalFlowDecorator>();
+    arrayList.add(null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    logicalFlowDecoratorDao.addDecorators(arrayList);
+  }
+
+  @Test
+  public void deleteDecoratorsTest() throws Exception {
+    // Arrange
+    LogicalFlowDecoratorDao logicalFlowDecoratorDao = new LogicalFlowDecoratorDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    Long flowId = new Long(1L);
+    ArrayList<EntityReference> arrayList = new ArrayList<EntityReference>();
+    arrayList.add(null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    logicalFlowDecoratorDao.deleteDecorators(flowId, arrayList);
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    LogicalFlowDecoratorDao logicalFlowDecoratorDao = new LogicalFlowDecoratorDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    logicalFlowDecoratorDao.findAll();
+  }
+
+  @Test
+  public void findByFlowIdsAndKindTest() throws Exception {
+    // Arrange
+    LogicalFlowDecoratorDao logicalFlowDecoratorDao = new LogicalFlowDecoratorDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+    EntityKind decorationKind = EntityKind.ACTOR;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    logicalFlowDecoratorDao.findByFlowIdsAndKind(arrayList, decorationKind);
+  }
+
+  @Test
+  public void findByFlowIdsTest() throws Exception {
+    // Arrange
+    LogicalFlowDecoratorDao logicalFlowDecoratorDao = new LogicalFlowDecoratorDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    logicalFlowDecoratorDao.findByFlowIds(arrayList);
+  }
+
+  @Test
+  public void getByFlowIdAndDecoratorRefTest() throws Exception {
+    // Arrange
+    LogicalFlowDecoratorDao logicalFlowDecoratorDao = new LogicalFlowDecoratorDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long flowId = 1L;
+    ImmutableEntityReference decoratorRef = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    logicalFlowDecoratorDao.getByFlowIdAndDecoratorRef(flowId, decoratorRef);
+  }
+
+  @Test
+  public void removeAllDecoratorsForFlowIdsTest() throws Exception {
+    // Arrange
+    LogicalFlowDecoratorDao logicalFlowDecoratorDao = new LogicalFlowDecoratorDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    logicalFlowDecoratorDao.removeAllDecoratorsForFlowIds(arrayList);
+  }
+
+  @Test
+  public void summarizeForAllTest() throws Exception {
+    // Arrange
+    LogicalFlowDecoratorDao logicalFlowDecoratorDao = new LogicalFlowDecoratorDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    logicalFlowDecoratorDao.summarizeForAll();
+  }
+
+  @Test
+  public void updateDecoratorsTest() throws Exception {
+    // Arrange
+    LogicalFlowDecoratorDao logicalFlowDecoratorDao = new LogicalFlowDecoratorDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    HashSet<LogicalFlowDecorator> hashSet = new HashSet<LogicalFlowDecorator>();
+    hashSet.add(null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    logicalFlowDecoratorDao.updateDecorators(hashSet);
+  }
+
+  @Test
+  public void updateRatingsByConditionTest() throws Exception {
+    // Arrange
+    LogicalFlowDecoratorDao logicalFlowDecoratorDao = new LogicalFlowDecoratorDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    AuthoritativenessRating rating = AuthoritativenessRating.PRIMARY;
+    Condition condition = Whitebox.newInstance(Condition.class);
+
+    // Act and Assert
+    thrown.expect(ClassCastException.class);
+    logicalFlowDecoratorDao.updateRatingsByCondition(rating, condition);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/data_type/DataTypeDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/data_type/DataTypeDaoTest.java
@@ -1,0 +1,62 @@
+package com.khartec.waltz.data.data_type;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class DataTypeDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void DataTypeDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new DataTypeDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    DataTypeDao dataTypeDao = new DataTypeDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    dataTypeDao.findAll();
+  }
+
+  @Test
+  public void getByCodeTest() throws Exception {
+    // Arrange
+    DataTypeDao dataTypeDao = new DataTypeDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String code = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    dataTypeDao.getByCode(code);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    DataTypeDao dataTypeDao = new DataTypeDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long dataTypeId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    dataTypeDao.getById(dataTypeId);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/data_type/DataTypeIdSelectorFactoryTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/data_type/DataTypeIdSelectorFactoryTest.java
@@ -1,0 +1,23 @@
+package com.khartec.waltz.data.data_type;
+
+import com.khartec.waltz.model.ImmutableIdSelectionOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class DataTypeIdSelectorFactoryTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void mkForOptionsTest() throws Exception {
+    // Arrange
+    DataTypeIdSelectorFactory dataTypeIdSelectorFactory = new DataTypeIdSelectorFactory();
+    ImmutableIdSelectionOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    dataTypeIdSelectorFactory.mkForOptions(options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/data_type/search/DataTypeSearchDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/data_type/search/DataTypeSearchDaoTest.java
@@ -1,0 +1,37 @@
+package com.khartec.waltz.data.data_type.search;
+
+import com.khartec.waltz.data.data_type.DataTypeDao;
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class DataTypeSearchDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void DataTypeSearchDaoTest() throws Exception {
+    // Arrange
+    DataTypeDao dataTypeDao = new DataTypeDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act
+    new DataTypeSearchDao(dataTypeDao);
+  }
+
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    DataTypeSearchDao dataTypeSearchDao = new DataTypeSearchDao(
+        new DataTypeDao(new DefaultDSLContext(new DefaultConfiguration())));
+    String query = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    dataTypeSearchDao.search(query, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/data_type_usage/DataTypeUsageDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/data_type_usage/DataTypeUsageDaoTest.java
@@ -1,0 +1,110 @@
+package com.khartec.waltz.data.data_type_usage;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.usage_info.UsageInfo;
+import com.khartec.waltz.model.usage_info.UsageKind;
+import org.jooq.exception.DataAccessException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class DataTypeUsageDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void DataTypeUsageDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new DataTypeUsageDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void deleteUsageInfoTest() throws Exception {
+    // Arrange
+    DataTypeUsageDao dataTypeUsageDao = new DataTypeUsageDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+    Long dataTypeId = new Long(1L);
+    ArrayList<UsageKind> arrayList = new ArrayList<UsageKind>();
+    arrayList.add(UsageKind.CONSUMER);
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    dataTypeUsageDao.deleteUsageInfo(ref, dataTypeId, arrayList);
+  }
+
+  @Test
+  public void findForEntityAndDataTypeTest() throws Exception {
+    // Arrange
+    DataTypeUsageDao dataTypeUsageDao = new DataTypeUsageDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+    Long dataTypeId = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    dataTypeUsageDao.findForEntityAndDataType(ref, dataTypeId);
+  }
+
+  @Test
+  public void findForEntityTest() throws Exception {
+    // Arrange
+    DataTypeUsageDao dataTypeUsageDao = new DataTypeUsageDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    dataTypeUsageDao.findForEntity(ref);
+  }
+
+  @Test
+  public void insertUsageInfoTest() throws Exception {
+    // Arrange
+    DataTypeUsageDao dataTypeUsageDao = new DataTypeUsageDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+    Long dataTypeId = new Long(1L);
+    ArrayList<UsageInfo> arrayList = new ArrayList<UsageInfo>();
+    arrayList.add(null);
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    dataTypeUsageDao.insertUsageInfo(ref, dataTypeId, arrayList);
+  }
+
+  @Test
+  public void recalculateForAllApplicationsTest() throws Exception {
+    // Arrange
+    DataTypeUsageDao dataTypeUsageDao = new DataTypeUsageDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DataAccessException.class);
+    dataTypeUsageDao.recalculateForAllApplications();
+  }
+
+  @Test
+  public void updateUsageInfoTest() throws Exception {
+    // Arrange
+    DataTypeUsageDao dataTypeUsageDao = new DataTypeUsageDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+    Long dataTypeId = new Long(1L);
+    ArrayList<UsageInfo> arrayList = new ArrayList<UsageInfo>();
+    arrayList.add(null);
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    dataTypeUsageDao.updateUsageInfo(ref, dataTypeId, arrayList);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/database_information/DatabaseInformationDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/database_information/DatabaseInformationDaoTest.java
@@ -1,0 +1,42 @@
+package com.khartec.waltz.data.database_information;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class DatabaseInformationDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void DatabaseInformationDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new DatabaseInformationDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findByApplicationIdTest() throws Exception {
+    // Arrange
+    DatabaseInformationDao databaseInformationDao = new DatabaseInformationDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    databaseInformationDao.findByApplicationId(id);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/drill_grid/DrillGridDefinitionDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/drill_grid/DrillGridDefinitionDaoTest.java
@@ -1,0 +1,54 @@
+package com.khartec.waltz.data.drill_grid;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class DrillGridDefinitionDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void DrillGridDefinitionDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new DrillGridDefinitionDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    DrillGridDefinitionDao drillGridDefinitionDao = new DrillGridDefinitionDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    drillGridDefinitionDao.findAll();
+  }
+
+  @Test
+  public void updateDescriptionTest() throws Exception {
+    // Arrange
+    DrillGridDefinitionDao drillGridDefinitionDao = new DrillGridDefinitionDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+    String description = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    drillGridDefinitionDao.updateDescription(id, description);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/end_user_app/EndUserAppDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/end_user_app/EndUserAppDaoTest.java
@@ -1,0 +1,40 @@
+package com.khartec.waltz.data.end_user_app;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class EndUserAppDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void EndUserAppDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new EndUserAppDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void countByOrganisationalUnitTest() throws Exception {
+    // Arrange
+    EndUserAppDao endUserAppDao = new EndUserAppDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    endUserAppDao.countByOrganisationalUnit();
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/end_user_app/EndUserAppIdSelectorFactoryTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/end_user_app/EndUserAppIdSelectorFactoryTest.java
@@ -1,0 +1,23 @@
+package com.khartec.waltz.data.end_user_app;
+
+import com.khartec.waltz.model.ImmutableIdSelectionOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class EndUserAppIdSelectorFactoryTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void applyTest() throws Exception {
+    // Arrange
+    EndUserAppIdSelectorFactory endUserAppIdSelectorFactory = new EndUserAppIdSelectorFactory();
+    ImmutableIdSelectionOptions options = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    endUserAppIdSelectorFactory.apply(options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/entity_alias/EntityAliasDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/entity_alias/EntityAliasDaoTest.java
@@ -1,0 +1,56 @@
+package com.khartec.waltz.data.entity_alias;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class EntityAliasDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void EntityAliasDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new EntityAliasDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findAliasesForEntityReferenceTest() throws Exception {
+    // Arrange
+    EntityAliasDao entityAliasDao = new EntityAliasDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    entityAliasDao.findAliasesForEntityReference(ref);
+  }
+
+  @Test
+  public void updateAliasesTest() throws Exception {
+    // Arrange
+    EntityAliasDao entityAliasDao = new EntityAliasDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+    ArrayList<String> arrayList = new ArrayList<String>();
+    arrayList.add("aaaaa");
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    entityAliasDao.updateAliases(ref, arrayList);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/entity_enum/EntityEnumDefinitionDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/entity_enum/EntityEnumDefinitionDaoTest.java
@@ -1,0 +1,43 @@
+package com.khartec.waltz.data.entity_enum;
+
+import com.khartec.waltz.model.EntityKind;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class EntityEnumDefinitionDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void EntityEnumDefinitionDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new EntityEnumDefinitionDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findByEntityKindTest() throws Exception {
+    // Arrange
+    EntityEnumDefinitionDao entityEnumDefinitionDao = new EntityEnumDefinitionDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    EntityKind kind = EntityKind.ACTOR;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    entityEnumDefinitionDao.findByEntityKind(kind);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/entity_enum/EntityEnumValueDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/entity_enum/EntityEnumValueDaoTest.java
@@ -1,0 +1,41 @@
+package com.khartec.waltz.data.entity_enum;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class EntityEnumValueDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void EntityEnumValueDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new EntityEnumValueDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findByEntityTest() throws Exception {
+    // Arrange
+    EntityEnumValueDao entityEnumValueDao = new EntityEnumValueDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    entityEnumValueDao.findByEntity(ref);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/entity_hierarchy/EntityHierarchyDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/entity_hierarchy/EntityHierarchyDaoTest.java
@@ -1,0 +1,60 @@
+package com.khartec.waltz.data.entity_hierarchy;
+
+import com.khartec.waltz.model.EntityKind;
+import com.khartec.waltz.model.entity_hierarchy.EntityHierarchyItem;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+public class EntityHierarchyDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void EntityHierarchyDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext dsl = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new EntityHierarchyDao(dsl);
+  }
+
+  @Test
+  public void getRootTalliesTest() throws Exception {
+    // Arrange
+    EntityHierarchyDao entityHierarchyDao = new EntityHierarchyDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    entityHierarchyDao.getRootTallies();
+  }
+
+  @Test
+  public void replaceHierarchyTest() throws Exception {
+    // Arrange
+    EntityHierarchyDao entityHierarchyDao = new EntityHierarchyDao(new DefaultDSLContext(new DefaultConfiguration()));
+    EntityKind kind = EntityKind.ACTOR;
+    ArrayList<EntityHierarchyItem> arrayList = new ArrayList<EntityHierarchyItem>();
+    arrayList.add(null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    entityHierarchyDao.replaceHierarchy(kind, arrayList);
+  }
+
+  @Test
+  public void tallyByKindTest() throws Exception {
+    // Arrange
+    EntityHierarchyDao entityHierarchyDao = new EntityHierarchyDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    entityHierarchyDao.tallyByKind();
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/entity_hierarchy/EntityRootsSelectorFactoryTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/entity_hierarchy/EntityRootsSelectorFactoryTest.java
@@ -1,0 +1,16 @@
+package com.khartec.waltz.data.entity_hierarchy;
+
+import com.khartec.waltz.model.EntityKind;
+import org.junit.Test;
+
+public class EntityRootsSelectorFactoryTest {  
+  @Test
+  public void applyTest() throws Exception {
+    // Arrange
+    EntityRootsSelectorFactory entityRootsSelectorFactory = new EntityRootsSelectorFactory();
+    EntityKind entityKind = EntityKind.ACTOR;
+
+    // Act
+    entityRootsSelectorFactory.apply(entityKind);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/entity_named_note/EntityNamedNoteDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/entity_named_note/EntityNamedNoteDaoTest.java
@@ -1,0 +1,79 @@
+package com.khartec.waltz.data.entity_named_note;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.ImmutableUserTimestamp;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class EntityNamedNoteDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void EntityNamedNoteDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new EntityNamedNoteDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findByEntityReferenceTest() throws Exception {
+    // Arrange
+    EntityNamedNoteDao entityNamedNoteDao = new EntityNamedNoteDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    entityNamedNoteDao.findByEntityReference(ref);
+  }
+
+  @Test
+  public void removeTest() throws Exception {
+    // Arrange
+    EntityNamedNoteDao entityNamedNoteDao = new EntityNamedNoteDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    entityNamedNoteDao.remove(ref);
+  }
+
+  @Test
+  public void removeTest2() throws Exception {
+    // Arrange
+    EntityNamedNoteDao entityNamedNoteDao = new EntityNamedNoteDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+    long namedNoteTypeId = 1L;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    entityNamedNoteDao.remove(ref, namedNoteTypeId);
+  }
+
+  @Test
+  public void saveTest() throws Exception {
+    // Arrange
+    EntityNamedNoteDao entityNamedNoteDao = new EntityNamedNoteDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+    long namedNoteTypeId = 1L;
+    String noteText = "aaaaa";
+    ImmutableUserTimestamp lastUpdate = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    entityNamedNoteDao.save(ref, namedNoteTypeId, noteText, lastUpdate);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/entity_named_note/EntityNamedNoteTypeDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/entity_named_note/EntityNamedNoteTypeDaoTest.java
@@ -1,0 +1,91 @@
+package com.khartec.waltz.data.entity_named_note;
+
+import com.khartec.waltz.model.entity_named_note.ImmutableEntityNamedNoteTypeChangeCommand;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class EntityNamedNoteTypeDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void EntityNamedNoteTypeDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new EntityNamedNoteTypeDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    EntityNamedNoteTypeDao entityNamedNoteTypeDao = new EntityNamedNoteTypeDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityNamedNoteTypeChangeCommand command = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    entityNamedNoteTypeDao.create(command);
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    EntityNamedNoteTypeDao entityNamedNoteTypeDao = new EntityNamedNoteTypeDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    entityNamedNoteTypeDao.findAll();
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    EntityNamedNoteTypeDao entityNamedNoteTypeDao = new EntityNamedNoteTypeDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long namedNoteTypeId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    entityNamedNoteTypeDao.getById(namedNoteTypeId);
+  }
+
+  @Test
+  public void removeByIdTest() throws Exception {
+    // Arrange
+    EntityNamedNoteTypeDao entityNamedNoteTypeDao = new EntityNamedNoteTypeDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    Long id = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    entityNamedNoteTypeDao.removeById(id);
+  }
+
+  @Test
+  public void updateTest() throws Exception {
+    // Arrange
+    EntityNamedNoteTypeDao entityNamedNoteTypeDao = new EntityNamedNoteTypeDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+    ImmutableEntityNamedNoteTypeChangeCommand command = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    entityNamedNoteTypeDao.update(id, command);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/entity_relationship/EntityRelationshipDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/entity_relationship/EntityRelationshipDaoTest.java
@@ -1,0 +1,156 @@
+package com.khartec.waltz.data.entity_relationship;
+
+import com.khartec.waltz.data.ImmutableGenericSelector;
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.entity_relationship.ImmutableEntityRelationship;
+import com.khartec.waltz.model.entity_relationship.ImmutableEntityRelationshipKey;
+import com.khartec.waltz.model.entity_relationship.ImmutableUpdateEntityRelationshipParams;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class EntityRelationshipDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void EntityRelationshipDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new EntityRelationshipDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    EntityRelationshipDao entityRelationshipDao = new EntityRelationshipDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityRelationship relationship = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    entityRelationshipDao.create(relationship);
+  }
+
+  @Test
+  public void deleteForGenericEntitySelectorTest() throws Exception {
+    // Arrange
+    EntityRelationshipDao entityRelationshipDao = new EntityRelationshipDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableGenericSelector selector = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    entityRelationshipDao.deleteForGenericEntitySelector(selector);
+  }
+
+  @Test
+  public void findForGenericEntitySelectorTest() throws Exception {
+    // Arrange
+    EntityRelationshipDao entityRelationshipDao = new EntityRelationshipDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableGenericSelector selector = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    entityRelationshipDao.findForGenericEntitySelector(selector);
+  }
+
+  @Test
+  public void findRelationshipsInvolvingTest() throws Exception {
+    // Arrange
+    EntityRelationshipDao entityRelationshipDao = new EntityRelationshipDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    entityRelationshipDao.findRelationshipsInvolving(ref);
+  }
+
+  @Test
+  public void removeAnyInvolvingTest() throws Exception {
+    // Arrange
+    EntityRelationshipDao entityRelationshipDao = new EntityRelationshipDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference entityReference = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    entityRelationshipDao.removeAnyInvolving(entityReference);
+  }
+
+  @Test
+  public void removeTest() throws Exception {
+    // Arrange
+    EntityRelationshipDao entityRelationshipDao = new EntityRelationshipDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityRelationship entityRelationship = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    entityRelationshipDao.remove(entityRelationship);
+  }
+
+  @Test
+  public void removeTest2() throws Exception {
+    // Arrange
+    EntityRelationshipDao entityRelationshipDao = new EntityRelationshipDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityRelationshipKey key = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    entityRelationshipDao.remove(key);
+  }
+
+  @Test
+  public void saveTest() throws Exception {
+    // Arrange
+    EntityRelationshipDao entityRelationshipDao = new EntityRelationshipDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityRelationship entityRelationship = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    entityRelationshipDao.save(entityRelationship);
+  }
+
+  @Test
+  public void tallyRelationshipsInvolvingTest() throws Exception {
+    // Arrange
+    EntityRelationshipDao entityRelationshipDao = new EntityRelationshipDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    entityRelationshipDao.tallyRelationshipsInvolving(ref);
+  }
+
+  @Test
+  public void updateTest() throws Exception {
+    // Arrange
+    EntityRelationshipDao entityRelationshipDao = new EntityRelationshipDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityRelationshipKey key = null;
+    ImmutableUpdateEntityRelationshipParams params = null;
+    String username = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    entityRelationshipDao.update(key, params, username);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/entity_statistic/EntityStatisticDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/entity_statistic/EntityStatisticDaoTest.java
@@ -1,0 +1,42 @@
+package com.khartec.waltz.data.entity_statistic;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class EntityStatisticDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void EntityStatisticDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new EntityStatisticDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findStatisticsForEntityTest() throws Exception {
+    // Arrange
+    EntityStatisticDao entityStatisticDao = new EntityStatisticDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+    boolean active = true;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    entityStatisticDao.findStatisticsForEntity(ref, active);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/entity_statistic/EntityStatisticDefinitionDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/entity_statistic/EntityStatisticDefinitionDaoTest.java
@@ -1,0 +1,95 @@
+package com.khartec.waltz.data.entity_statistic;
+
+import com.khartec.waltz.model.entity_statistic.ImmutableEntityStatisticDefinition;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class EntityStatisticDefinitionDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void EntityStatisticDefinitionDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new EntityStatisticDefinitionDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findAllActiveDefinitionsTest() throws Exception {
+    // Arrange
+    EntityStatisticDefinitionDao entityStatisticDefinitionDao = new EntityStatisticDefinitionDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    boolean rollupOnly = true;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    entityStatisticDefinitionDao.findAllActiveDefinitions(rollupOnly);
+  }
+
+  @Test
+  public void findByIdsTest() throws Exception {
+    // Arrange
+    EntityStatisticDefinitionDao entityStatisticDefinitionDao = new EntityStatisticDefinitionDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    entityStatisticDefinitionDao.findByIds(arrayList);
+  }
+
+  @Test
+  public void findRelatedTest() throws Exception {
+    // Arrange
+    EntityStatisticDefinitionDao entityStatisticDefinitionDao = new EntityStatisticDefinitionDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+    boolean rollupOnly = true;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    entityStatisticDefinitionDao.findRelated(id, rollupOnly);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    EntityStatisticDefinitionDao entityStatisticDefinitionDao = new EntityStatisticDefinitionDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    entityStatisticDefinitionDao.getById(id);
+  }
+
+  @Test
+  public void insertTest() throws Exception {
+    // Arrange
+    EntityStatisticDefinitionDao entityStatisticDefinitionDao = new EntityStatisticDefinitionDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityStatisticDefinition entityStatistic = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    entityStatisticDefinitionDao.insert(entityStatistic);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/entity_statistic/EntityStatisticSummaryDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/entity_statistic/EntityStatisticSummaryDaoTest.java
@@ -1,0 +1,79 @@
+package com.khartec.waltz.data.entity_statistic;
+
+import com.khartec.waltz.data.DBExecutorPool;
+import com.khartec.waltz.model.Duration;
+import com.khartec.waltz.model.ImmutableEntityReference;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class EntityStatisticSummaryDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void EntityStatisticSummaryDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+    DBExecutorPool dbExecutorPool = new DBExecutorPool(1, 1);
+
+    // Act
+    new EntityStatisticSummaryDao(defaultDSLContext, dbExecutorPool);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void generateHistoricWithNoRollupTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+    EntityStatisticSummaryDao entityStatisticSummaryDao = new EntityStatisticSummaryDao(defaultDSLContext,
+        new DBExecutorPool(1, 1));
+    Long statisticId = new Long(167772161L);
+    ImmutableEntityReference entityReference = null;
+    Duration duration = Duration.DAY;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    entityStatisticSummaryDao.generateHistoricWithNoRollup(statisticId, entityReference, duration);
+  }
+
+  @Test
+  public void generateWithNoRollupTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+    EntityStatisticSummaryDao entityStatisticSummaryDao = new EntityStatisticSummaryDao(defaultDSLContext,
+        new DBExecutorPool(1, 1));
+    Long statisticId = new Long(167772161L);
+    ImmutableEntityReference entityReference = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    entityStatisticSummaryDao.generateWithNoRollup(statisticId, entityReference);
+  }
+
+  @Test
+  public void generateWithNoRollupTest2() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+    EntityStatisticSummaryDao entityStatisticSummaryDao = new EntityStatisticSummaryDao(defaultDSLContext,
+        new DBExecutorPool(1, 1));
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(11L));
+    ImmutableEntityReference entityReference = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    entityStatisticSummaryDao.generateWithNoRollup(arrayList, entityReference);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/entity_statistic/EntityStatisticValueDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/entity_statistic/EntityStatisticValueDaoTest.java
@@ -1,0 +1,45 @@
+package com.khartec.waltz.data.entity_statistic;
+
+import com.khartec.waltz.model.entity_statistic.EntityStatisticValue;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class EntityStatisticValueDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void EntityStatisticValueDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new EntityStatisticValueDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void bulkSaveValuesTest() throws Exception {
+    // Arrange
+    EntityStatisticValueDao entityStatisticValueDao = new EntityStatisticValueDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<EntityStatisticValue> arrayList = new ArrayList<EntityStatisticValue>();
+    arrayList.add(null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    entityStatisticValueDao.bulkSaveValues(arrayList);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/entity_svg_diagram/EntitySvgDiagramDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/entity_svg_diagram/EntitySvgDiagramDaoTest.java
@@ -1,0 +1,42 @@
+package com.khartec.waltz.data.entity_svg_diagram;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class EntitySvgDiagramDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void EntitySvgDiagramDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new EntitySvgDiagramDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findForEntityReferenceTest() throws Exception {
+    // Arrange
+    EntitySvgDiagramDao entitySvgDiagramDao = new EntitySvgDiagramDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    entitySvgDiagramDao.findForEntityReference(ref);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/entity_workflow/EntityWorkflowDefinitionDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/entity_workflow/EntityWorkflowDefinitionDaoTest.java
@@ -1,0 +1,41 @@
+package com.khartec.waltz.data.entity_workflow;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class EntityWorkflowDefinitionDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void EntityWorkflowDefinitionDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new EntityWorkflowDefinitionDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    EntityWorkflowDefinitionDao entityWorkflowDefinitionDao = new EntityWorkflowDefinitionDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    entityWorkflowDefinitionDao.findAll();
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/entity_workflow/EntityWorkflowStateDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/entity_workflow/EntityWorkflowStateDaoTest.java
@@ -1,0 +1,43 @@
+package com.khartec.waltz.data.entity_workflow;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class EntityWorkflowStateDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void EntityWorkflowStateDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new EntityWorkflowStateDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void getByEntityReferenceAndWorkflowIdTest() throws Exception {
+    // Arrange
+    EntityWorkflowStateDao entityWorkflowStateDao = new EntityWorkflowStateDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long workflowId = 1L;
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    entityWorkflowStateDao.getByEntityReferenceAndWorkflowId(workflowId, ref);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/entity_workflow/EntityWorkflowTransitionDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/entity_workflow/EntityWorkflowTransitionDaoTest.java
@@ -1,0 +1,43 @@
+package com.khartec.waltz.data.entity_workflow;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class EntityWorkflowTransitionDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void EntityWorkflowTransitionDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new EntityWorkflowTransitionDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findForEntityReferenceAndWorkflowIdTest() throws Exception {
+    // Arrange
+    EntityWorkflowTransitionDao entityWorkflowTransitionDao = new EntityWorkflowTransitionDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long workflowId = 1L;
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    entityWorkflowTransitionDao.findForEntityReferenceAndWorkflowId(workflowId, ref);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/enum_value/EnumValueAliasDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/enum_value/EnumValueAliasDaoTest.java
@@ -1,0 +1,42 @@
+package com.khartec.waltz.data.enum_value;
+
+import com.khartec.waltz.model.enum_value.EnumValueKind;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class EnumValueAliasDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void EnumValueAliasDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new EnumValueAliasDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void mkAliasesTest() throws Exception {
+    // Arrange
+    EnumValueAliasDao enumValueAliasDao = new EnumValueAliasDao(new DefaultDSLContext(new DefaultConfiguration()));
+    EnumValueKind kind = EnumValueKind.TRANSPORT_KIND;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    enumValueAliasDao.mkAliases(kind);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/enum_value/EnumValueDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/enum_value/EnumValueDaoTest.java
@@ -1,0 +1,51 @@
+package com.khartec.waltz.data.enum_value;
+
+import com.khartec.waltz.model.enum_value.EnumValueKind;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class EnumValueDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void EnumValueDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new EnumValueDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    EnumValueDao enumValueDao = new EnumValueDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    enumValueDao.findAll();
+  }
+
+  @Test
+  public void mkExistsConditionTest() throws Exception {
+    // Arrange
+    EnumValueKind kind = EnumValueKind.TRANSPORT_KIND;
+    String key = "aaaaa";
+
+    // Act
+    EnumValueDao.mkExistsCondition(kind, key);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/external_identifier/ExternalIdentifierDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/external_identifier/ExternalIdentifierDaoTest.java
@@ -1,0 +1,124 @@
+package com.khartec.waltz.data.external_identifier;
+
+import com.khartec.waltz.model.EntityKind;
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.external_identifier.ExternalIdentifier;
+import com.khartec.waltz.model.external_identifier.ImmutableExternalIdentifier;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+
+public class ExternalIdentifierDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void ExternalIdentifierDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new ExternalIdentifierDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    ExternalIdentifierDao externalIdentifierDao = new ExternalIdentifierDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    HashSet<ExternalIdentifier> hashSet = new HashSet<ExternalIdentifier>();
+    hashSet.add(null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    externalIdentifierDao.create(hashSet);
+  }
+
+  @Test
+  public void createTest2() throws Exception {
+    // Arrange
+    ExternalIdentifierDao externalIdentifierDao = new ExternalIdentifierDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableExternalIdentifier externalIdentifier = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    externalIdentifierDao.create(externalIdentifier);
+  }
+
+  @Test
+  public void deleteTest() throws Exception {
+    // Arrange
+    ExternalIdentifierDao externalIdentifierDao = new ExternalIdentifierDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference entityRef = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    externalIdentifierDao.delete(entityRef);
+  }
+
+  @Test
+  public void deleteTest2() throws Exception {
+    // Arrange
+    ExternalIdentifierDao externalIdentifierDao = new ExternalIdentifierDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableExternalIdentifier externalIdentifier = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    externalIdentifierDao.delete(externalIdentifier);
+  }
+
+  @Test
+  public void deleteTest3() throws Exception {
+    // Arrange
+    ExternalIdentifierDao externalIdentifierDao = new ExternalIdentifierDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<ExternalIdentifier> arrayList = new ArrayList<ExternalIdentifier>();
+    arrayList.add(null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    externalIdentifierDao.delete(arrayList);
+  }
+
+  @Test
+  public void findByEntityReferenceTest() throws Exception {
+    // Arrange
+    ExternalIdentifierDao externalIdentifierDao = new ExternalIdentifierDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference entityRef = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    externalIdentifierDao.findByEntityReference(entityRef);
+  }
+
+  @Test
+  public void findByKindTest() throws Exception {
+    // Arrange
+    ExternalIdentifierDao externalIdentifierDao = new ExternalIdentifierDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    EntityKind kind = EntityKind.ACTOR;
+    String extId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    externalIdentifierDao.findByKind(kind, extId);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/flow_diagram/FlowDiagramAnnotationDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/flow_diagram/FlowDiagramAnnotationDaoTest.java
@@ -1,0 +1,83 @@
+package com.khartec.waltz.data.flow_diagram;
+
+import com.khartec.waltz.model.flow_diagram.FlowDiagramAnnotation;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class FlowDiagramAnnotationDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void FlowDiagramAnnotationDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new FlowDiagramAnnotationDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void cloneTest() throws Exception {
+    // Arrange
+    FlowDiagramAnnotationDao flowDiagramAnnotationDao = new FlowDiagramAnnotationDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long diagramId = 1L;
+    Long clonedDiagramId = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    flowDiagramAnnotationDao.clone(diagramId, clonedDiagramId);
+  }
+
+  @Test
+  public void createAnnotationsTest() throws Exception {
+    // Arrange
+    FlowDiagramAnnotationDao flowDiagramAnnotationDao = new FlowDiagramAnnotationDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<FlowDiagramAnnotation> arrayList = new ArrayList<FlowDiagramAnnotation>();
+    arrayList.add(null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    flowDiagramAnnotationDao.createAnnotations(arrayList);
+  }
+
+  @Test
+  public void deleteForDiagramTest() throws Exception {
+    // Arrange
+    FlowDiagramAnnotationDao flowDiagramAnnotationDao = new FlowDiagramAnnotationDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long diagramId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    flowDiagramAnnotationDao.deleteForDiagram(diagramId);
+  }
+
+  @Test
+  public void findByDiagramIdTest() throws Exception {
+    // Arrange
+    FlowDiagramAnnotationDao flowDiagramAnnotationDao = new FlowDiagramAnnotationDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long diagramId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    flowDiagramAnnotationDao.findByDiagramId(diagramId);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/flow_diagram/FlowDiagramDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/flow_diagram/FlowDiagramDaoTest.java
@@ -1,0 +1,124 @@
+package com.khartec.waltz.data.flow_diagram;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.flow_diagram.ImmutableFlowDiagram;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class FlowDiagramDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void FlowDiagramDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new FlowDiagramDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void cloneTest() throws Exception {
+    // Arrange
+    FlowDiagramDao flowDiagramDao = new FlowDiagramDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long diagramId = 1L;
+    String newName = "aaaaa";
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    flowDiagramDao.clone(diagramId, newName, userId);
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    FlowDiagramDao flowDiagramDao = new FlowDiagramDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableFlowDiagram flowDiagram = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    flowDiagramDao.create(flowDiagram);
+  }
+
+  @Test
+  public void deleteByIdTest() throws Exception {
+    // Arrange
+    FlowDiagramDao flowDiagramDao = new FlowDiagramDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    flowDiagramDao.deleteById(id);
+  }
+
+  @Test
+  public void findByEntityReferenceTest() throws Exception {
+    // Arrange
+    FlowDiagramDao flowDiagramDao = new FlowDiagramDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    flowDiagramDao.findByEntityReference(ref);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    FlowDiagramDao flowDiagramDao = new FlowDiagramDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    flowDiagramDao.getById(id);
+  }
+
+  @Test
+  public void updateDescriptionTest() throws Exception {
+    // Arrange
+    FlowDiagramDao flowDiagramDao = new FlowDiagramDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+    String des = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    flowDiagramDao.updateDescription(id, des);
+  }
+
+  @Test
+  public void updateNameTest() throws Exception {
+    // Arrange
+    FlowDiagramDao flowDiagramDao = new FlowDiagramDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+    String name = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    flowDiagramDao.updateName(id, name);
+  }
+
+  @Test
+  public void updateTest() throws Exception {
+    // Arrange
+    FlowDiagramDao flowDiagramDao = new FlowDiagramDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableFlowDiagram flowDiagram = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    flowDiagramDao.update(flowDiagram);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/flow_diagram/FlowDiagramEntityDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/flow_diagram/FlowDiagramEntityDaoTest.java
@@ -1,0 +1,122 @@
+package com.khartec.waltz.data.flow_diagram;
+
+import com.khartec.waltz.data.ImmutableGenericSelector;
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.flow_diagram.FlowDiagramEntity;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class FlowDiagramEntityDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void FlowDiagramEntityDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new FlowDiagramEntityDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void cloneTest() throws Exception {
+    // Arrange
+    FlowDiagramEntityDao flowDiagramEntityDao = new FlowDiagramEntityDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long diagramId = 1L;
+    Long clonedDiagramId = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    flowDiagramEntityDao.clone(diagramId, clonedDiagramId);
+  }
+
+  @Test
+  public void createEntitiesTest() throws Exception {
+    // Arrange
+    FlowDiagramEntityDao flowDiagramEntityDao = new FlowDiagramEntityDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<FlowDiagramEntity> arrayList = new ArrayList<FlowDiagramEntity>();
+    arrayList.add(null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    flowDiagramEntityDao.createEntities(arrayList);
+  }
+
+  @Test
+  public void deleteEntityForDiagramTest() throws Exception {
+    // Arrange
+    FlowDiagramEntityDao flowDiagramEntityDao = new FlowDiagramEntityDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long diagramId = 1L;
+    ImmutableEntityReference entityReference = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    flowDiagramEntityDao.deleteEntityForDiagram(diagramId, entityReference);
+  }
+
+  @Test
+  public void deleteForDiagramTest() throws Exception {
+    // Arrange
+    FlowDiagramEntityDao flowDiagramEntityDao = new FlowDiagramEntityDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long diagramId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    flowDiagramEntityDao.deleteForDiagram(diagramId);
+  }
+
+  @Test
+  public void deleteForGenericEntitySelectorTest() throws Exception {
+    // Arrange
+    FlowDiagramEntityDao flowDiagramEntityDao = new FlowDiagramEntityDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableGenericSelector selector = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    flowDiagramEntityDao.deleteForGenericEntitySelector(selector);
+  }
+
+  @Test
+  public void findForDiagramTest() throws Exception {
+    // Arrange
+    FlowDiagramEntityDao flowDiagramEntityDao = new FlowDiagramEntityDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long diagramId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    flowDiagramEntityDao.findForDiagram(diagramId);
+  }
+
+  @Test
+  public void findForEntityTest() throws Exception {
+    // Arrange
+    FlowDiagramEntityDao flowDiagramEntityDao = new FlowDiagramEntityDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    flowDiagramEntityDao.findForEntity(ref);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/flow_diagram/FlowDiagramIdSelectorFactoryTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/flow_diagram/FlowDiagramIdSelectorFactoryTest.java
@@ -1,0 +1,23 @@
+package com.khartec.waltz.data.flow_diagram;
+
+import com.khartec.waltz.model.ImmutableIdSelectionOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class FlowDiagramIdSelectorFactoryTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void applyTest() throws Exception {
+    // Arrange
+    FlowDiagramIdSelectorFactory flowDiagramIdSelectorFactory = new FlowDiagramIdSelectorFactory();
+    ImmutableIdSelectionOptions options = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    flowDiagramIdSelectorFactory.apply(options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/involvement/InvolvementDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/involvement/InvolvementDaoTest.java
@@ -1,0 +1,143 @@
+package com.khartec.waltz.data.involvement;
+
+import com.khartec.waltz.data.ImmutableGenericSelector;
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.involvement.ImmutableInvolvement;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class InvolvementDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void InvolvementDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new InvolvementDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void deleteByGenericEntitySelectorTest() throws Exception {
+    // Arrange
+    InvolvementDao involvementDao = new InvolvementDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableGenericSelector genericSelector = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    involvementDao.deleteByGenericEntitySelector(genericSelector);
+  }
+
+  @Test
+  public void findAllApplicationsByEmployeeIdTest() throws Exception {
+    // Arrange
+    InvolvementDao involvementDao = new InvolvementDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String employeeId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    involvementDao.findAllApplicationsByEmployeeId(employeeId);
+  }
+
+  @Test
+  public void findByEmployeeIdTest() throws Exception {
+    // Arrange
+    InvolvementDao involvementDao = new InvolvementDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String employeeId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    involvementDao.findByEmployeeId(employeeId);
+  }
+
+  @Test
+  public void findByEntityReferenceTest() throws Exception {
+    // Arrange
+    InvolvementDao involvementDao = new InvolvementDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    involvementDao.findByEntityReference(ref);
+  }
+
+  @Test
+  public void findByGenericEntitySelectorTest() throws Exception {
+    // Arrange
+    InvolvementDao involvementDao = new InvolvementDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableGenericSelector genericSelector = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    involvementDao.findByGenericEntitySelector(genericSelector);
+  }
+
+  @Test
+  public void findDirectApplicationsByEmployeeIdTest() throws Exception {
+    // Arrange
+    InvolvementDao involvementDao = new InvolvementDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String employeeId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    involvementDao.findDirectApplicationsByEmployeeId(employeeId);
+  }
+
+  @Test
+  public void findPeopleByEntityReferenceTest() throws Exception {
+    // Arrange
+    InvolvementDao involvementDao = new InvolvementDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    involvementDao.findPeopleByEntityReference(ref);
+  }
+
+  @Test
+  public void findPeopleByGenericEntitySelectorTest() throws Exception {
+    // Arrange
+    InvolvementDao involvementDao = new InvolvementDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableGenericSelector selector = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    involvementDao.findPeopleByGenericEntitySelector(selector);
+  }
+
+  @Test
+  public void removeTest() throws Exception {
+    // Arrange
+    InvolvementDao involvementDao = new InvolvementDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableInvolvement involvement = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    involvementDao.remove(involvement);
+  }
+
+  @Test
+  public void saveTest() throws Exception {
+    // Arrange
+    InvolvementDao involvementDao = new InvolvementDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableInvolvement involvement = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    involvementDao.save(involvement);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/involvement_kind/InvolvementKindDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/involvement_kind/InvolvementKindDaoTest.java
@@ -1,0 +1,99 @@
+package com.khartec.waltz.data.involvement_kind;
+
+import com.khartec.waltz.model.EntityKind;
+import com.khartec.waltz.model.involvement_kind.ImmutableInvolvementKindChangeCommand;
+import com.khartec.waltz.model.involvement_kind.ImmutableInvolvementKindCreateCommand;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class InvolvementKindDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void InvolvementKindDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new InvolvementKindDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    InvolvementKindDao involvementKindDao = new InvolvementKindDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableInvolvementKindCreateCommand command = null;
+    String username = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    involvementKindDao.create(command, username);
+  }
+
+  @Test
+  public void deleteIfNotUsedTest() throws Exception {
+    // Arrange
+    InvolvementKindDao involvementKindDao = new InvolvementKindDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    involvementKindDao.deleteIfNotUsed(id);
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    InvolvementKindDao involvementKindDao = new InvolvementKindDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    involvementKindDao.findAll();
+  }
+
+  @Test
+  public void findKeyInvolvementKindsByEntityKindTest() throws Exception {
+    // Arrange
+    InvolvementKindDao involvementKindDao = new InvolvementKindDao(new DefaultDSLContext(new DefaultConfiguration()));
+    EntityKind kind = EntityKind.ACTOR;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    involvementKindDao.findKeyInvolvementKindsByEntityKind(kind);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    InvolvementKindDao involvementKindDao = new InvolvementKindDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    involvementKindDao.getById(id);
+  }
+
+  @Test
+  public void updateTest() throws Exception {
+    // Arrange
+    InvolvementKindDao involvementKindDao = new InvolvementKindDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableInvolvementKindChangeCommand command = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    involvementKindDao.update(command);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/licence/LicenceDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/licence/LicenceDaoTest.java
@@ -1,0 +1,61 @@
+package com.khartec.waltz.data.licence;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class LicenceDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void LicenceDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new LicenceDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void countApplicationsTest() throws Exception {
+    // Arrange
+    LicenceDao licenceDao = new LicenceDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    licenceDao.countApplications();
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    LicenceDao licenceDao = new LicenceDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    licenceDao.findAll();
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    LicenceDao licenceDao = new LicenceDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    licenceDao.getById(id);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/licence/LicenceIdSelectorFactoryTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/licence/LicenceIdSelectorFactoryTest.java
@@ -1,0 +1,23 @@
+package com.khartec.waltz.data.licence;
+
+import com.khartec.waltz.model.ImmutableIdSelectionOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class LicenceIdSelectorFactoryTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void mkForOptionsTest() throws Exception {
+    // Arrange
+    LicenceIdSelectorFactory licenceIdSelectorFactory = new LicenceIdSelectorFactory();
+    ImmutableIdSelectionOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    licenceIdSelectorFactory.mkForOptions(options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/logical_data_element/LogicalDataElementDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/logical_data_element/LogicalDataElementDaoTest.java
@@ -1,0 +1,65 @@
+package com.khartec.waltz.data.logical_data_element;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class LogicalDataElementDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void LogicalDataElementDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new LogicalDataElementDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    LogicalDataElementDao logicalDataElementDao = new LogicalDataElementDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    logicalDataElementDao.findAll();
+  }
+
+  @Test
+  public void getByExternalIdTest() throws Exception {
+    // Arrange
+    LogicalDataElementDao logicalDataElementDao = new LogicalDataElementDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    String externalId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    logicalDataElementDao.getByExternalId(externalId);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    LogicalDataElementDao logicalDataElementDao = new LogicalDataElementDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    logicalDataElementDao.getById(id);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/logical_data_element/LogicalDataElementIdSelectorFactoryTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/logical_data_element/LogicalDataElementIdSelectorFactoryTest.java
@@ -1,0 +1,23 @@
+package com.khartec.waltz.data.logical_data_element;
+
+import com.khartec.waltz.model.ImmutableIdSelectionOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class LogicalDataElementIdSelectorFactoryTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void applyTest() throws Exception {
+    // Arrange
+    LogicalDataElementIdSelectorFactory logicalDataElementIdSelectorFactory = new LogicalDataElementIdSelectorFactory();
+    ImmutableIdSelectionOptions options = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    logicalDataElementIdSelectorFactory.apply(options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/logical_data_element/search/LogicalDataElementSearchDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/logical_data_element/search/LogicalDataElementSearchDaoTest.java
@@ -1,0 +1,43 @@
+package com.khartec.waltz.data.logical_data_element.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class LogicalDataElementSearchDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void LogicalDataElementSearchDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new LogicalDataElementSearchDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    LogicalDataElementSearchDao logicalDataElementSearchDao = new LogicalDataElementSearchDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    String termsStr = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    logicalDataElementSearchDao.search(termsStr, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/logical_flow/LogicalFlowDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/logical_flow/LogicalFlowDaoTest.java
@@ -1,0 +1,197 @@
+package com.khartec.waltz.data.logical_flow;
+
+import com.khartec.waltz.model.EntityReference;
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.logical_flow.ImmutableLogicalFlow;
+import com.khartec.waltz.model.logical_flow.LogicalFlow;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.jooq.lambda.tuple.Tuple2;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class LogicalFlowDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void LogicalFlowDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new LogicalFlowDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void addFlowTest() throws Exception {
+    // Arrange
+    LogicalFlowDao logicalFlowDao = new LogicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableLogicalFlow flow = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    logicalFlowDao.addFlow(flow);
+  }
+
+  @Test
+  public void addFlowsTest() throws Exception {
+    // Arrange
+    LogicalFlowDao logicalFlowDao = new LogicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<LogicalFlow> arrayList = new ArrayList<LogicalFlow>();
+    arrayList.add(null);
+    String user = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    logicalFlowDao.addFlows(arrayList, user);
+  }
+
+  @Test
+  public void cleanupOrphansTest() throws Exception {
+    // Arrange
+    LogicalFlowDao logicalFlowDao = new LogicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    logicalFlowDao.cleanupOrphans();
+  }
+
+  @Test
+  public void cleanupSelfReferencingFlowsTest() throws Exception {
+    // Arrange
+    LogicalFlowDao logicalFlowDao = new LogicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    logicalFlowDao.cleanupSelfReferencingFlows();
+  }
+
+  @Test
+  public void findActiveByFlowIdsTest() throws Exception {
+    // Arrange
+    LogicalFlowDao logicalFlowDao = new LogicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    logicalFlowDao.findActiveByFlowIds(arrayList);
+  }
+
+  @Test
+  public void findAllActiveTest() throws Exception {
+    // Arrange
+    LogicalFlowDao logicalFlowDao = new LogicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    logicalFlowDao.findAllActive();
+  }
+
+  @Test
+  public void findAllByFlowIdsTest() throws Exception {
+    // Arrange
+    LogicalFlowDao logicalFlowDao = new LogicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    logicalFlowDao.findAllByFlowIds(arrayList);
+  }
+
+  @Test
+  public void findByEntityReferenceTest() throws Exception {
+    // Arrange
+    LogicalFlowDao logicalFlowDao = new LogicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    logicalFlowDao.findByEntityReference(ref);
+  }
+
+  @Test
+  public void findBySourcesAndTargetsTest() throws Exception {
+    // Arrange
+    LogicalFlowDao logicalFlowDao = new LogicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<Tuple2<EntityReference, EntityReference>> arrayList = new ArrayList<Tuple2<EntityReference, EntityReference>>();
+    arrayList.add(new Tuple2<EntityReference, EntityReference>(null, null));
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    logicalFlowDao.findBySourcesAndTargets(arrayList);
+  }
+
+  @Test
+  public void findUpstreamFlowsForEntityReferencesTest() throws Exception {
+    // Arrange
+    LogicalFlowDao logicalFlowDao = new LogicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<EntityReference> arrayList = new ArrayList<EntityReference>();
+    arrayList.add(null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    logicalFlowDao.findUpstreamFlowsForEntityReferences(arrayList);
+  }
+
+  @Test
+  public void getByFlowIdTest() throws Exception {
+    // Arrange
+    LogicalFlowDao logicalFlowDao = new LogicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long dataFlowId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    logicalFlowDao.getByFlowId(dataFlowId);
+  }
+
+  @Test
+  public void getBySourceAndTargetTest() throws Exception {
+    // Arrange
+    LogicalFlowDao logicalFlowDao = new LogicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference source = null;
+    ImmutableEntityReference target = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    logicalFlowDao.getBySourceAndTarget(source, target);
+  }
+
+  @Test
+  public void removeFlowTest() throws Exception {
+    // Arrange
+    LogicalFlowDao logicalFlowDao = new LogicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    Long flowId = new Long(1L);
+    String user = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    logicalFlowDao.removeFlow(flowId, user);
+  }
+
+  @Test
+  public void restoreFlowTest() throws Exception {
+    // Arrange
+    LogicalFlowDao logicalFlowDao = new LogicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long logicalFlowId = 1L;
+    String username = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    logicalFlowDao.restoreFlow(logicalFlowId, username);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/logical_flow/LogicalFlowIdSelectorFactoryTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/logical_flow/LogicalFlowIdSelectorFactoryTest.java
@@ -1,0 +1,23 @@
+package com.khartec.waltz.data.logical_flow;
+
+import com.khartec.waltz.model.ImmutableIdSelectionOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class LogicalFlowIdSelectorFactoryTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void applyTest() throws Exception {
+    // Arrange
+    LogicalFlowIdSelectorFactory logicalFlowIdSelectorFactory = new LogicalFlowIdSelectorFactory();
+    ImmutableIdSelectionOptions options = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    logicalFlowIdSelectorFactory.apply(options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/logical_flow/LogicalFlowStatsDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/logical_flow/LogicalFlowStatsDaoTest.java
@@ -1,0 +1,25 @@
+package com.khartec.waltz.data.logical_flow;
+
+import com.khartec.waltz.data.DBExecutorPool;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class LogicalFlowStatsDaoTest {
+  @Test
+  public void LogicalFlowStatsDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+    DBExecutorPool dbExecutorPool = new DBExecutorPool(1, 1);
+
+    // Act
+    new LogicalFlowStatsDao(defaultDSLContext, dbExecutorPool);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/measurable/MeasurableDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/measurable/MeasurableDaoTest.java
@@ -1,0 +1,162 @@
+package com.khartec.waltz.data.measurable;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.measurable.ImmutableMeasurable;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class MeasurableDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void MeasurableDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new MeasurableDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    MeasurableDao measurableDao = new MeasurableDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableMeasurable measurable = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    measurableDao.create(measurable);
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    MeasurableDao measurableDao = new MeasurableDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    measurableDao.findAll();
+  }
+
+  @Test
+  public void findByCategoryIdTest() throws Exception {
+    // Arrange
+    MeasurableDao measurableDao = new MeasurableDao(new DefaultDSLContext(new DefaultConfiguration()));
+    Long categoryId = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    measurableDao.findByCategoryId(categoryId);
+  }
+
+  @Test
+  public void findByExternalIdTest() throws Exception {
+    // Arrange
+    MeasurableDao measurableDao = new MeasurableDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String extId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    measurableDao.findByExternalId(extId);
+  }
+
+  @Test
+  public void findMeasuresRelatedToEntityTest() throws Exception {
+    // Arrange
+    MeasurableDao measurableDao = new MeasurableDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    measurableDao.findMeasuresRelatedToEntity(ref);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    MeasurableDao measurableDao = new MeasurableDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    measurableDao.getById(id);
+  }
+
+  @Test
+  public void updateConcreteFlagTest() throws Exception {
+    // Arrange
+    MeasurableDao measurableDao = new MeasurableDao(new DefaultDSLContext(new DefaultConfiguration()));
+    Long id = new Long(1L);
+    boolean newValue = true;
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    measurableDao.updateConcreteFlag(id, newValue, userId);
+  }
+
+  @Test
+  public void updateDescriptionTest() throws Exception {
+    // Arrange
+    MeasurableDao measurableDao = new MeasurableDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+    String newValue = "aaaaa";
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    measurableDao.updateDescription(id, newValue, userId);
+  }
+
+  @Test
+  public void updateExternalIdTest() throws Exception {
+    // Arrange
+    MeasurableDao measurableDao = new MeasurableDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+    String newValue = "aaaaa";
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    measurableDao.updateExternalId(id, newValue, userId);
+  }
+
+  @Test
+  public void updateNameTest() throws Exception {
+    // Arrange
+    MeasurableDao measurableDao = new MeasurableDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+    String newValue = "aaaaa";
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    measurableDao.updateName(id, newValue, userId);
+  }
+
+  @Test
+  public void updateParentIdTest() throws Exception {
+    // Arrange
+    MeasurableDao measurableDao = new MeasurableDao(new DefaultDSLContext(new DefaultConfiguration()));
+    Long measurableId = new Long(1L);
+    Long destinationId = new Long(1L);
+    String userId = "akaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    measurableDao.updateParentId(measurableId, destinationId, userId);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/measurable/MeasurableIdSelectorFactoryTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/measurable/MeasurableIdSelectorFactoryTest.java
@@ -1,0 +1,23 @@
+package com.khartec.waltz.data.measurable;
+
+import com.khartec.waltz.model.ImmutableIdSelectionOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class MeasurableIdSelectorFactoryTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void applyTest() throws Exception {
+    // Arrange
+    MeasurableIdSelectorFactory measurableIdSelectorFactory = new MeasurableIdSelectorFactory();
+    ImmutableIdSelectionOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    measurableIdSelectorFactory.apply(options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/measurable/search/MariaMeasurableSearchTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/measurable/search/MariaMeasurableSearchTest.java
@@ -1,0 +1,27 @@
+package com.khartec.waltz.data.measurable.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class MariaMeasurableSearchTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    MariaMeasurableSearch mariaMeasurableSearch = new MariaMeasurableSearch();
+    DefaultDSLContext dsl = new DefaultDSLContext(new DefaultConfiguration());
+    String query = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    mariaMeasurableSearch.search(dsl, query, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/measurable/search/MeasurableSearchDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/measurable/search/MeasurableSearchDaoTest.java
@@ -1,0 +1,42 @@
+package com.khartec.waltz.data.measurable.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import com.khartec.waltz.model.measurable.Measurable;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class MeasurableSearchDaoTest {
+  @Test
+  public void MeasurableSearchDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new MeasurableSearchDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    MeasurableSearchDao measurableSearchDao = new MeasurableSearchDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    String terms = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act
+    List<Measurable> actual = measurableSearchDao.search(terms, options);
+
+    // Assert
+    assertEquals(0, actual.size());
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/measurable/search/PostgresMeasurableSearchTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/measurable/search/PostgresMeasurableSearchTest.java
@@ -1,0 +1,27 @@
+package com.khartec.waltz.data.measurable.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class PostgresMeasurableSearchTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    PostgresMeasurableSearch postgresMeasurableSearch = new PostgresMeasurableSearch();
+    DefaultDSLContext dsl = new DefaultDSLContext(new DefaultConfiguration());
+    String query = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    postgresMeasurableSearch.search(dsl, query, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/measurable/search/SqlServerMeasurableSearchTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/measurable/search/SqlServerMeasurableSearchTest.java
@@ -1,0 +1,27 @@
+package com.khartec.waltz.data.measurable.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SqlServerMeasurableSearchTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    SqlServerMeasurableSearch sqlServerMeasurableSearch = new SqlServerMeasurableSearch();
+    DefaultDSLContext dsl = new DefaultDSLContext(new DefaultConfiguration());
+    String query = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    sqlServerMeasurableSearch.search(dsl, query, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/measurable_category/MeasurableCategoryDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/measurable_category/MeasurableCategoryDaoTest.java
@@ -1,0 +1,53 @@
+package com.khartec.waltz.data.measurable_category;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class MeasurableCategoryDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void MeasurableCategoryDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new MeasurableCategoryDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    MeasurableCategoryDao measurableCategoryDao = new MeasurableCategoryDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    measurableCategoryDao.findAll();
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    MeasurableCategoryDao measurableCategoryDao = new MeasurableCategoryDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    measurableCategoryDao.getById(id);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/measurable_rating/MeasurableRatingDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/measurable_rating/MeasurableRatingDaoTest.java
@@ -1,0 +1,118 @@
+package com.khartec.waltz.data.measurable_rating;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.measurable_rating.ImmutableRemoveMeasurableRatingCommand;
+import com.khartec.waltz.model.measurable_rating.ImmutableSaveMeasurableRatingCommand;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class MeasurableRatingDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void MeasurableRatingDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new MeasurableRatingDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    MeasurableRatingDao measurableRatingDao = new MeasurableRatingDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableSaveMeasurableRatingCommand command = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    measurableRatingDao.create(command);
+  }
+
+  @Test
+  public void findByCategoryTest() throws Exception {
+    // Arrange
+    MeasurableRatingDao measurableRatingDao = new MeasurableRatingDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    measurableRatingDao.findByCategory(id);
+  }
+
+  @Test
+  public void findForEntityTest() throws Exception {
+    // Arrange
+    MeasurableRatingDao measurableRatingDao = new MeasurableRatingDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    measurableRatingDao.findForEntity(ref);
+  }
+
+  @Test
+  public void removeForCategoryTest() throws Exception {
+    // Arrange
+    MeasurableRatingDao measurableRatingDao = new MeasurableRatingDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+    long categoryId = 1L;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    measurableRatingDao.removeForCategory(ref, categoryId);
+  }
+
+  @Test
+  public void removeTest() throws Exception {
+    // Arrange
+    MeasurableRatingDao measurableRatingDao = new MeasurableRatingDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableRemoveMeasurableRatingCommand command = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    measurableRatingDao.remove(command);
+  }
+
+  @Test
+  public void tallyByMeasurableCategoryIdTest() throws Exception {
+    // Arrange
+    MeasurableRatingDao measurableRatingDao = new MeasurableRatingDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long categoryId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    measurableRatingDao.tallyByMeasurableCategoryId(categoryId);
+  }
+
+  @Test
+  public void updateTest() throws Exception {
+    // Arrange
+    MeasurableRatingDao measurableRatingDao = new MeasurableRatingDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableSaveMeasurableRatingCommand command = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    measurableRatingDao.update(command);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/notification/NotificationDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/notification/NotificationDaoTest.java
@@ -1,0 +1,41 @@
+package com.khartec.waltz.data.notification;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class NotificationDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void NotificationDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new NotificationDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findNotificationsByUserIdTest() throws Exception {
+    // Arrange
+    NotificationDao notificationDao = new NotificationDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    notificationDao.findNotificationsByUserId(userId);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/orgunit/OrganisationalUnitDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/orgunit/OrganisationalUnitDaoTest.java
@@ -1,0 +1,143 @@
+package com.khartec.waltz.data.orgunit;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class OrganisationalUnitDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void OrganisationalUnitDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext dsl = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    OrganisationalUnitDao organisationalUnitDao = new OrganisationalUnitDao(dsl);
+
+    // Assert
+    assertEquals(
+        "OrganisationalUnitDao{dsl=DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]}",
+        organisationalUnitDao.toString());
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    OrganisationalUnitDao organisationalUnitDao = new OrganisationalUnitDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    organisationalUnitDao.findAll();
+  }
+
+  @Test
+  public void findByIdsTest() throws Exception {
+    // Arrange
+    OrganisationalUnitDao organisationalUnitDao = new OrganisationalUnitDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    Long resultLong = new Long(1L);
+    Long[] ids = new Long[]{resultLong, new Long(1L), resultLong};
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    organisationalUnitDao.findByIds(ids);
+  }
+
+  @Test
+  public void findDescendantsTest() throws Exception {
+    // Arrange
+    OrganisationalUnitDao organisationalUnitDao = new OrganisationalUnitDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    organisationalUnitDao.findDescendants(id);
+  }
+
+  @Test
+  public void findImmediateHierarchyTest() throws Exception {
+    // Arrange
+    OrganisationalUnitDao organisationalUnitDao = new OrganisationalUnitDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    organisationalUnitDao.findImmediateHierarchy(id);
+  }
+
+  @Test
+  public void findRelatedByEntityRefTest() throws Exception {
+    // Arrange
+    OrganisationalUnitDao organisationalUnitDao = new OrganisationalUnitDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    organisationalUnitDao.findRelatedByEntityRef(ref);
+  }
+
+  @Test
+  public void getByAppIdTest() throws Exception {
+    // Arrange
+    OrganisationalUnitDao organisationalUnitDao = new OrganisationalUnitDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    organisationalUnitDao.getByAppId(id);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    OrganisationalUnitDao organisationalUnitDao = new OrganisationalUnitDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    organisationalUnitDao.getById(id);
+  }
+
+  @Test
+  public void toStringTest() throws Exception {
+    // Arrange
+    OrganisationalUnitDao organisationalUnitDao = new OrganisationalUnitDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act
+    String actual = organisationalUnitDao.toString();
+
+    // Assert
+    assertEquals(
+        "OrganisationalUnitDao{dsl=DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]}",
+        actual);
+  }
+
+  @Test
+  public void updateDescriptionTest() throws Exception {
+    // Arrange
+    OrganisationalUnitDao organisationalUnitDao = new OrganisationalUnitDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+    String description = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    organisationalUnitDao.updateDescription(id, description);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/orgunit/OrganisationalUnitIdSelectorFactoryTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/orgunit/OrganisationalUnitIdSelectorFactoryTest.java
@@ -1,0 +1,23 @@
+package com.khartec.waltz.data.orgunit;
+
+import com.khartec.waltz.model.ImmutableIdSelectionOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class OrganisationalUnitIdSelectorFactoryTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void mkForOptionsTest() throws Exception {
+    // Arrange
+    OrganisationalUnitIdSelectorFactory organisationalUnitIdSelectorFactory = new OrganisationalUnitIdSelectorFactory();
+    ImmutableIdSelectionOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    organisationalUnitIdSelectorFactory.mkForOptions(options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/orgunit/search/MariaOrganisationalUnitSearchTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/orgunit/search/MariaOrganisationalUnitSearchTest.java
@@ -1,0 +1,27 @@
+package com.khartec.waltz.data.orgunit.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class MariaOrganisationalUnitSearchTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    MariaOrganisationalUnitSearch mariaOrganisationalUnitSearch = new MariaOrganisationalUnitSearch();
+    DefaultDSLContext dsl = new DefaultDSLContext(new DefaultConfiguration());
+    String terms = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    mariaOrganisationalUnitSearch.search(dsl, terms, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/orgunit/search/OrganisationalUnitSearchDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/orgunit/search/OrganisationalUnitSearchDaoTest.java
@@ -1,0 +1,42 @@
+package com.khartec.waltz.data.orgunit.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import com.khartec.waltz.model.orgunit.OrganisationalUnit;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class OrganisationalUnitSearchDaoTest {
+  @Test
+  public void OrganisationalUnitSearchDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new OrganisationalUnitSearchDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    OrganisationalUnitSearchDao organisationalUnitSearchDao = new OrganisationalUnitSearchDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    String terms = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act
+    List<OrganisationalUnit> actual = organisationalUnitSearchDao.search(terms, options);
+
+    // Assert
+    assertEquals(0, actual.size());
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/orgunit/search/PostgresOrganisationalUnitSearchTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/orgunit/search/PostgresOrganisationalUnitSearchTest.java
@@ -1,0 +1,27 @@
+package com.khartec.waltz.data.orgunit.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class PostgresOrganisationalUnitSearchTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    PostgresOrganisationalUnitSearch postgresOrganisationalUnitSearch = new PostgresOrganisationalUnitSearch();
+    DefaultDSLContext dsl = new DefaultDSLContext(new DefaultConfiguration());
+    String terms = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    postgresOrganisationalUnitSearch.search(dsl, terms, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/orgunit/search/SqlServerOrganisationalUnitSearchTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/orgunit/search/SqlServerOrganisationalUnitSearchTest.java
@@ -1,0 +1,27 @@
+package com.khartec.waltz.data.orgunit.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SqlServerOrganisationalUnitSearchTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    SqlServerOrganisationalUnitSearch sqlServerOrganisationalUnitSearch = new SqlServerOrganisationalUnitSearch();
+    DefaultDSLContext dsl = new DefaultDSLContext(new DefaultConfiguration());
+    String query = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    sqlServerOrganisationalUnitSearch.search(dsl, query, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/orphan/OrphanDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/orphan/OrphanDaoTest.java
@@ -1,0 +1,120 @@
+package com.khartec.waltz.data.orphan;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class OrphanDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void OrphanDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new OrphanDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findApplicationsWithNonExistentOrgUnitTest() throws Exception {
+    // Arrange
+    OrphanDao orphanDao = new OrphanDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    orphanDao.findApplicationsWithNonExistentOrgUnit();
+  }
+
+  @Test
+  public void findOrphanAttestatationsTest() throws Exception {
+    // Arrange
+    OrphanDao orphanDao = new OrphanDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    orphanDao.findOrphanAttestatations();
+  }
+
+  @Test
+  public void findOrphanAuthoritativeSourceByAppTest() throws Exception {
+    // Arrange
+    OrphanDao orphanDao = new OrphanDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    orphanDao.findOrphanAuthoritativeSourceByApp();
+  }
+
+  @Test
+  public void findOrphanAuthoritativeSourceByOrgUnitTest() throws Exception {
+    // Arrange
+    OrphanDao orphanDao = new OrphanDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    orphanDao.findOrphanAuthoritativeSourceByOrgUnit();
+  }
+
+  @Test
+  public void findOrphanAuthoritiveSourceByDataTypeTest() throws Exception {
+    // Arrange
+    OrphanDao orphanDao = new OrphanDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    orphanDao.findOrphanAuthoritiveSourceByDataType();
+  }
+
+  @Test
+  public void findOrphanChangeInitiativesTest() throws Exception {
+    // Arrange
+    OrphanDao orphanDao = new OrphanDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    orphanDao.findOrphanChangeInitiatives();
+  }
+
+  @Test
+  public void findOrphanLogicalDataFlowsTest() throws Exception {
+    // Arrange
+    OrphanDao orphanDao = new OrphanDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    orphanDao.findOrphanLogicalDataFlows();
+  }
+
+  @Test
+  public void findOrphanMeasurableRatingsTest() throws Exception {
+    // Arrange
+    OrphanDao orphanDao = new OrphanDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    orphanDao.findOrphanMeasurableRatings();
+  }
+
+  @Test
+  public void findOrphanPhysicalFlowsTest() throws Exception {
+    // Arrange
+    OrphanDao orphanDao = new OrphanDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    orphanDao.findOrphanPhysicalFlows();
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/person/PersonDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/person/PersonDaoTest.java
@@ -1,0 +1,156 @@
+package com.khartec.waltz.data.person;
+
+import com.khartec.waltz.model.person.ImmutablePerson;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+
+public class PersonDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void PersonDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new PersonDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void allTest() throws Exception {
+    // Arrange
+    PersonDao personDao = new PersonDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    personDao.all();
+  }
+
+  @Test
+  public void bulkSaveTest() throws Exception {
+    // Arrange
+    PersonDao personDao = new PersonDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<ImmutablePerson> arrayList = new ArrayList<ImmutablePerson>();
+    arrayList.add(null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    personDao.bulkSave(arrayList);
+  }
+
+  @Test
+  public void countAllUnderlingsByKindTest() throws Exception {
+    // Arrange
+    PersonDao personDao = new PersonDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String employeeId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    personDao.countAllUnderlingsByKind(employeeId);
+  }
+
+  @Test
+  public void findAllManagersByEmployeeIdTest() throws Exception {
+    // Arrange
+    PersonDao personDao = new PersonDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String employeeId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    personDao.findAllManagersByEmployeeId(employeeId);
+  }
+
+  @Test
+  public void findByIdsTest() throws Exception {
+    // Arrange
+    PersonDao personDao = new PersonDao(new DefaultDSLContext(new DefaultConfiguration()));
+    HashSet<Long> hashSet = new HashSet<Long>();
+    hashSet.add(new Long(1L));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    personDao.findByIds(hashSet);
+  }
+
+  @Test
+  public void findDirectsByEmployeeIdTest() throws Exception {
+    // Arrange
+    PersonDao personDao = new PersonDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String employeeId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    personDao.findDirectsByEmployeeId(employeeId);
+  }
+
+  @Test
+  public void findPersonsByAttestationInstanceIdTest() throws Exception {
+    // Arrange
+    PersonDao personDao = new PersonDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long instanceId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    personDao.findPersonsByAttestationInstanceId(instanceId);
+  }
+
+  @Test
+  public void getActiveByUserEmailTest() throws Exception {
+    // Arrange
+    PersonDao personDao = new PersonDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String email = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    personDao.getActiveByUserEmail(email);
+  }
+
+  @Test
+  public void getByEmployeeIdTest() throws Exception {
+    // Arrange
+    PersonDao personDao = new PersonDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String employeeId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    personDao.getByEmployeeId(employeeId);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    PersonDao personDao = new PersonDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    personDao.getById(id);
+  }
+
+  @Test
+  public void getByUserEmailTest() throws Exception {
+    // Arrange
+    PersonDao personDao = new PersonDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String email = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    personDao.getByUserEmail(email);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/person/search/MariaPersonSearchTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/person/search/MariaPersonSearchTest.java
@@ -1,0 +1,27 @@
+package com.khartec.waltz.data.person.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class MariaPersonSearchTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    MariaPersonSearch mariaPersonSearch = new MariaPersonSearch();
+    DefaultDSLContext dsl = new DefaultDSLContext(new DefaultConfiguration());
+    String terms = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    mariaPersonSearch.search(dsl, terms, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/person/search/PersonSearchDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/person/search/PersonSearchDaoTest.java
@@ -1,0 +1,41 @@
+package com.khartec.waltz.data.person.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import com.khartec.waltz.model.person.Person;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class PersonSearchDaoTest {
+  @Test
+  public void PersonSearchDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new PersonSearchDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    PersonSearchDao personSearchDao = new PersonSearchDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String terms = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act
+    List<Person> actual = personSearchDao.search(terms, options);
+
+    // Assert
+    assertEquals(0, actual.size());
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/person/search/PostgresPersonSearchTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/person/search/PostgresPersonSearchTest.java
@@ -1,0 +1,27 @@
+package com.khartec.waltz.data.person.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class PostgresPersonSearchTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    PostgresPersonSearch postgresPersonSearch = new PostgresPersonSearch();
+    DefaultDSLContext dsl = new DefaultDSLContext(new DefaultConfiguration());
+    String terms = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    postgresPersonSearch.search(dsl, terms, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/person/search/SqlServerPersonSearchTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/person/search/SqlServerPersonSearchTest.java
@@ -1,0 +1,27 @@
+package com.khartec.waltz.data.person.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SqlServerPersonSearchTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    SqlServerPersonSearch sqlServerPersonSearch = new SqlServerPersonSearch();
+    DefaultDSLContext dsl = new DefaultDSLContext(new DefaultConfiguration());
+    String query = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    sqlServerPersonSearch.search(dsl, query, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/perspective_definition/PerspectiveDefinitionDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/perspective_definition/PerspectiveDefinitionDaoTest.java
@@ -1,0 +1,54 @@
+package com.khartec.waltz.data.perspective_definition;
+
+import com.khartec.waltz.model.perspective.ImmutablePerspectiveDefinition;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class PerspectiveDefinitionDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void PerspectiveDefinitionDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new PerspectiveDefinitionDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    PerspectiveDefinitionDao perspectiveDefinitionDao = new PerspectiveDefinitionDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutablePerspectiveDefinition perspectiveDefinition = null;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    perspectiveDefinitionDao.create(perspectiveDefinition);
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    PerspectiveDefinitionDao perspectiveDefinitionDao = new PerspectiveDefinitionDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    perspectiveDefinitionDao.findAll();
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/perspective_rating/PerspectiveRatingDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/perspective_rating/PerspectiveRatingDaoTest.java
@@ -1,0 +1,101 @@
+package com.khartec.waltz.data.perspective_rating;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.perspective.PerspectiveRatingValue;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+
+public class PerspectiveRatingDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void PerspectiveRatingDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new PerspectiveRatingDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void addTest() throws Exception {
+    // Arrange
+    PerspectiveRatingDao perspectiveRatingDao = new PerspectiveRatingDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+    HashSet<PerspectiveRatingValue> hashSet = new HashSet<PerspectiveRatingValue>();
+    hashSet.add(null);
+    String username = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    perspectiveRatingDao.add(ref, hashSet, username);
+  }
+
+  @Test
+  public void cascadeRemovalOfMeasurableRatingTest() throws Exception {
+    // Arrange
+    PerspectiveRatingDao perspectiveRatingDao = new PerspectiveRatingDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference entityReference = null;
+    long measurableId = 1L;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    perspectiveRatingDao.cascadeRemovalOfMeasurableRating(entityReference, measurableId);
+  }
+
+  @Test
+  public void findForEntityTest() throws Exception {
+    // Arrange
+    PerspectiveRatingDao perspectiveRatingDao = new PerspectiveRatingDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    perspectiveRatingDao.findForEntity(ref);
+  }
+
+  @Test
+  public void findForEntityTest2() throws Exception {
+    // Arrange
+    PerspectiveRatingDao perspectiveRatingDao = new PerspectiveRatingDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long categoryX = 1L;
+    long categoryY = 1L;
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    perspectiveRatingDao.findForEntity(categoryX, categoryY, ref);
+  }
+
+  @Test
+  public void removeTest() throws Exception {
+    // Arrange
+    PerspectiveRatingDao perspectiveRatingDao = new PerspectiveRatingDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+    HashSet<PerspectiveRatingValue> hashSet = new HashSet<PerspectiveRatingValue>();
+    hashSet.add(null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    perspectiveRatingDao.remove(ref, hashSet);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/physical_flow/PhysicalFlowDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/physical_flow/PhysicalFlowDaoTest.java
@@ -1,0 +1,287 @@
+package com.khartec.waltz.data.physical_flow;
+
+import com.khartec.waltz.model.Criticality;
+import com.khartec.waltz.model.EntityLifecycleStatus;
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.physical_flow.FrequencyKind;
+import com.khartec.waltz.model.physical_flow.ImmutablePhysicalFlow;
+import com.khartec.waltz.model.physical_flow.ImmutablePhysicalFlowParsed;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class PhysicalFlowDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void PhysicalFlowDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new PhysicalFlowDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void cleanupOrphansTest() throws Exception {
+    // Arrange
+    PhysicalFlowDao physicalFlowDao = new PhysicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalFlowDao.cleanupOrphans();
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    PhysicalFlowDao physicalFlowDao = new PhysicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutablePhysicalFlow flow = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    physicalFlowDao.create(flow);
+  }
+
+  @Test
+  public void deleteTest() throws Exception {
+    // Arrange
+    PhysicalFlowDao physicalFlowDao = new PhysicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long flowId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalFlowDao.delete(flowId);
+  }
+
+  @Test
+  public void findByAttributesAndSpecificationTest() throws Exception {
+    // Arrange
+    PhysicalFlowDao physicalFlowDao = new PhysicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutablePhysicalFlow flow = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    physicalFlowDao.findByAttributesAndSpecification(flow);
+  }
+
+  @Test
+  public void findByConsumerTest() throws Exception {
+    // Arrange
+    PhysicalFlowDao physicalFlowDao = new PhysicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    physicalFlowDao.findByConsumer(ref);
+  }
+
+  @Test
+  public void findByEntityReferenceTest() throws Exception {
+    // Arrange
+    PhysicalFlowDao physicalFlowDao = new PhysicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    physicalFlowDao.findByEntityReference(ref);
+  }
+
+  @Test
+  public void findByExternalIdTest() throws Exception {
+    // Arrange
+    PhysicalFlowDao physicalFlowDao = new PhysicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String externalId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalFlowDao.findByExternalId(externalId);
+  }
+
+  @Test
+  public void findByProducerAndConsumerTest() throws Exception {
+    // Arrange
+    PhysicalFlowDao physicalFlowDao = new PhysicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference producer = null;
+    ImmutableEntityReference consumer = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    physicalFlowDao.findByProducerAndConsumer(producer, consumer);
+  }
+
+  @Test
+  public void findByProducerTest() throws Exception {
+    // Arrange
+    PhysicalFlowDao physicalFlowDao = new PhysicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    physicalFlowDao.findByProducer(ref);
+  }
+
+  @Test
+  public void findBySpecificationIdTest() throws Exception {
+    // Arrange
+    PhysicalFlowDao physicalFlowDao = new PhysicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long specificationId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalFlowDao.findBySpecificationId(specificationId);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    PhysicalFlowDao physicalFlowDao = new PhysicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalFlowDao.getById(id);
+  }
+
+  @Test
+  public void getByParsedFlowTest() throws Exception {
+    // Arrange
+    PhysicalFlowDao physicalFlowDao = new PhysicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutablePhysicalFlowParsed flow = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    physicalFlowDao.getByParsedFlow(flow);
+  }
+
+  @Test
+  public void hasPhysicalFlowsTest() throws Exception {
+    // Arrange
+    PhysicalFlowDao physicalFlowDao = new PhysicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long logicalFlowId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalFlowDao.hasPhysicalFlows(logicalFlowId);
+  }
+
+  @Test
+  public void matchPhysicalFlowTest() throws Exception {
+    // Arrange
+    PhysicalFlowDao physicalFlowDao = new PhysicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutablePhysicalFlow flow = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    physicalFlowDao.matchPhysicalFlow(flow);
+  }
+
+  @Test
+  public void updateBasisOffsetTest() throws Exception {
+    // Arrange
+    PhysicalFlowDao physicalFlowDao = new PhysicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long flowId = 1L;
+    int basis = 1;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalFlowDao.updateBasisOffset(flowId, basis);
+  }
+
+  @Test
+  public void updateCriticalityTest() throws Exception {
+    // Arrange
+    PhysicalFlowDao physicalFlowDao = new PhysicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long flowId = 1L;
+    Criticality criticality = Criticality.LOW;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalFlowDao.updateCriticality(flowId, criticality);
+  }
+
+  @Test
+  public void updateDescriptionTest() throws Exception {
+    // Arrange
+    PhysicalFlowDao physicalFlowDao = new PhysicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long flowId = 1L;
+    String description = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalFlowDao.updateDescription(flowId, description);
+  }
+
+  @Test
+  public void updateEntityLifecycleStatusTest() throws Exception {
+    // Arrange
+    PhysicalFlowDao physicalFlowDao = new PhysicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long flowId = 1L;
+    EntityLifecycleStatus entityLifecycleStatus = EntityLifecycleStatus.ACTIVE;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalFlowDao.updateEntityLifecycleStatus(flowId, entityLifecycleStatus);
+  }
+
+  @Test
+  public void updateExternalIdTest() throws Exception {
+    // Arrange
+    PhysicalFlowDao physicalFlowDao = new PhysicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long flowId = 1L;
+    String externalId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalFlowDao.updateExternalId(flowId, externalId);
+  }
+
+  @Test
+  public void updateFrequencyTest() throws Exception {
+    // Arrange
+    PhysicalFlowDao physicalFlowDao = new PhysicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long flowId = 1L;
+    FrequencyKind frequencyKind = FrequencyKind.ON_DEMAND;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalFlowDao.updateFrequency(flowId, frequencyKind);
+  }
+
+  @Test
+  public void updateSpecDefinitionTest() throws Exception {
+    // Arrange
+    PhysicalFlowDao physicalFlowDao = new PhysicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String userName = "aaaaa";
+    long flowId = 1L;
+    long newSpecDefinitionId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalFlowDao.updateSpecDefinition(userName, flowId, newSpecDefinitionId);
+  }
+
+  @Test
+  public void updateTransportTest() throws Exception {
+    // Arrange
+    PhysicalFlowDao physicalFlowDao = new PhysicalFlowDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long flowId = 1L;
+    String transport = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalFlowDao.updateTransport(flowId, transport);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/physical_flow/PhysicalFlowIdSelectorFactoryTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/physical_flow/PhysicalFlowIdSelectorFactoryTest.java
@@ -1,0 +1,23 @@
+package com.khartec.waltz.data.physical_flow;
+
+import com.khartec.waltz.model.ImmutableIdSelectionOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class PhysicalFlowIdSelectorFactoryTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void applyTest() throws Exception {
+    // Arrange
+    PhysicalFlowIdSelectorFactory physicalFlowIdSelectorFactory = new PhysicalFlowIdSelectorFactory();
+    ImmutableIdSelectionOptions options = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    physicalFlowIdSelectorFactory.apply(options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/physical_flow/PhysicalFlowSearchDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/physical_flow/PhysicalFlowSearchDaoTest.java
@@ -1,0 +1,42 @@
+package com.khartec.waltz.data.physical_flow;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class PhysicalFlowSearchDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void PhysicalFlowSearchDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new PhysicalFlowSearchDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void searchReportsTest() throws Exception {
+    // Arrange
+    PhysicalFlowSearchDao physicalFlowSearchDao = new PhysicalFlowSearchDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    String query = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalFlowSearchDao.searchReports(query);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/physical_flow_participant/PhysicalFlowParticipantDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/physical_flow_participant/PhysicalFlowParticipantDaoTest.java
@@ -1,0 +1,85 @@
+package com.khartec.waltz.data.physical_flow_participant;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.physical_flow_participant.ParticipationKind;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class PhysicalFlowParticipantDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void PhysicalFlowParticipantDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new PhysicalFlowParticipantDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void addTest() throws Exception {
+    // Arrange
+    PhysicalFlowParticipantDao physicalFlowParticipantDao = new PhysicalFlowParticipantDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long physicalFlowId = 1L;
+    ParticipationKind participationKind = ParticipationKind.SOURCE;
+    ImmutableEntityReference participant = null;
+    String username = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    physicalFlowParticipantDao.add(physicalFlowId, participationKind, participant, username);
+  }
+
+  @Test
+  public void findByParticipantTest() throws Exception {
+    // Arrange
+    PhysicalFlowParticipantDao physicalFlowParticipantDao = new PhysicalFlowParticipantDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference entityReference = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    physicalFlowParticipantDao.findByParticipant(entityReference);
+  }
+
+  @Test
+  public void findByPhysicalFlowIdTest() throws Exception {
+    // Arrange
+    PhysicalFlowParticipantDao physicalFlowParticipantDao = new PhysicalFlowParticipantDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalFlowParticipantDao.findByPhysicalFlowId(id);
+  }
+
+  @Test
+  public void removeTest() throws Exception {
+    // Arrange
+    PhysicalFlowParticipantDao physicalFlowParticipantDao = new PhysicalFlowParticipantDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long physicalFlowId = 1L;
+    ParticipationKind participationKind = ParticipationKind.SOURCE;
+    ImmutableEntityReference participant = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    physicalFlowParticipantDao.remove(physicalFlowId, participationKind, participant);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/physical_specification/PhysicalSpecificationDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/physical_specification/PhysicalSpecificationDaoTest.java
@@ -1,0 +1,133 @@
+package com.khartec.waltz.data.physical_specification;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.physical_flow.ImmutablePhysicalFlowParsed;
+import com.khartec.waltz.model.physical_specification.ImmutablePhysicalSpecification;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class PhysicalSpecificationDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void PhysicalSpecificationDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new PhysicalSpecificationDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    PhysicalSpecificationDao physicalSpecificationDao = new PhysicalSpecificationDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutablePhysicalSpecification specification = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    physicalSpecificationDao.create(specification);
+  }
+
+  @Test
+  public void findByEntityReferenceTest() throws Exception {
+    // Arrange
+    PhysicalSpecificationDao physicalSpecificationDao = new PhysicalSpecificationDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    physicalSpecificationDao.findByEntityReference(ref);
+  }
+
+  @Test
+  public void findByIdsTest() throws Exception {
+    // Arrange
+    PhysicalSpecificationDao physicalSpecificationDao = new PhysicalSpecificationDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalSpecificationDao.findByIds(arrayList);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    PhysicalSpecificationDao physicalSpecificationDao = new PhysicalSpecificationDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalSpecificationDao.getById(id);
+  }
+
+  @Test
+  public void getByParsedFlowTest() throws Exception {
+    // Arrange
+    PhysicalSpecificationDao physicalSpecificationDao = new PhysicalSpecificationDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutablePhysicalFlowParsed flow = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    physicalSpecificationDao.getByParsedFlow(flow);
+  }
+
+  @Test
+  public void isUsedTest() throws Exception {
+    // Arrange
+    PhysicalSpecificationDao physicalSpecificationDao = new PhysicalSpecificationDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalSpecificationDao.isUsed(id);
+  }
+
+  @Test
+  public void markRemovedIfUnusedTest() throws Exception {
+    // Arrange
+    PhysicalSpecificationDao physicalSpecificationDao = new PhysicalSpecificationDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long specId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalSpecificationDao.markRemovedIfUnused(specId);
+  }
+
+  @Test
+  public void updateExternalIdTest() throws Exception {
+    // Arrange
+    PhysicalSpecificationDao physicalSpecificationDao = new PhysicalSpecificationDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long specificationId = 1L;
+    String externalId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalSpecificationDao.updateExternalId(specificationId, externalId);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/physical_specification/PhysicalSpecificationIdSelectorFactoryTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/physical_specification/PhysicalSpecificationIdSelectorFactoryTest.java
@@ -1,0 +1,23 @@
+package com.khartec.waltz.data.physical_specification;
+
+import com.khartec.waltz.model.ImmutableIdSelectionOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class PhysicalSpecificationIdSelectorFactoryTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void applyTest() throws Exception {
+    // Arrange
+    PhysicalSpecificationIdSelectorFactory physicalSpecificationIdSelectorFactory = new PhysicalSpecificationIdSelectorFactory();
+    ImmutableIdSelectionOptions options = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    physicalSpecificationIdSelectorFactory.apply(options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/physical_specification/search/PhysicalSpecificationSearchDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/physical_specification/search/PhysicalSpecificationSearchDaoTest.java
@@ -1,0 +1,43 @@
+package com.khartec.waltz.data.physical_specification.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class PhysicalSpecificationSearchDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void PhysicalSpecificationSearchDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new PhysicalSpecificationSearchDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    PhysicalSpecificationSearchDao physicalSpecificationSearchDao = new PhysicalSpecificationSearchDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    String termsStr = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    physicalSpecificationSearchDao.search(termsStr, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/physical_specification_data_type/PhysicalSpecDataTypeDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/physical_specification_data_type/PhysicalSpecDataTypeDaoTest.java
@@ -1,0 +1,95 @@
+package com.khartec.waltz.data.physical_specification_data_type;
+
+import com.khartec.waltz.model.physical_specification_data_type.PhysicalSpecificationDataType;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class PhysicalSpecDataTypeDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void PhysicalSpecDataTypeDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new PhysicalSpecDataTypeDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void addDataTypesTest() throws Exception {
+    // Arrange
+    PhysicalSpecDataTypeDao physicalSpecDataTypeDao = new PhysicalSpecDataTypeDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<PhysicalSpecificationDataType> arrayList = new ArrayList<PhysicalSpecificationDataType>();
+    arrayList.add(null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    physicalSpecDataTypeDao.addDataTypes(arrayList);
+  }
+
+  @Test
+  public void findBySpecificationIdTest() throws Exception {
+    // Arrange
+    PhysicalSpecDataTypeDao physicalSpecDataTypeDao = new PhysicalSpecDataTypeDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long specId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalSpecDataTypeDao.findBySpecificationId(specId);
+  }
+
+  @Test
+  public void getBySpecIdAndDataTypeIDTest() throws Exception {
+    // Arrange
+    PhysicalSpecDataTypeDao physicalSpecDataTypeDao = new PhysicalSpecDataTypeDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long specId = 1L;
+    long dataTypeId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalSpecDataTypeDao.getBySpecIdAndDataTypeID(specId, dataTypeId);
+  }
+
+  @Test
+  public void removeDataTypesTest() throws Exception {
+    // Arrange
+    PhysicalSpecDataTypeDao physicalSpecDataTypeDao = new PhysicalSpecDataTypeDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<PhysicalSpecificationDataType> arrayList = new ArrayList<PhysicalSpecificationDataType>();
+    arrayList.add(null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    physicalSpecDataTypeDao.removeDataTypes(arrayList);
+  }
+
+  @Test
+  public void rippleDataTypesToLogicalFlowsTest() throws Exception {
+    // Arrange
+    PhysicalSpecDataTypeDao physicalSpecDataTypeDao = new PhysicalSpecDataTypeDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalSpecDataTypeDao.rippleDataTypesToLogicalFlows();
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/physical_specification_definition/PhysicalSpecDefinitionDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/physical_specification_definition/PhysicalSpecDefinitionDaoTest.java
@@ -1,0 +1,107 @@
+package com.khartec.waltz.data.physical_specification_definition;
+
+import com.khartec.waltz.model.ReleaseLifecycleStatus;
+import com.khartec.waltz.model.physical_specification_definition.ImmutablePhysicalSpecDefinition;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class PhysicalSpecDefinitionDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void PhysicalSpecDefinitionDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new PhysicalSpecDefinitionDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    PhysicalSpecDefinitionDao physicalSpecDefinitionDao = new PhysicalSpecDefinitionDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutablePhysicalSpecDefinition specDefinition = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    physicalSpecDefinitionDao.create(specDefinition);
+  }
+
+  @Test
+  public void deleteTest() throws Exception {
+    // Arrange
+    PhysicalSpecDefinitionDao physicalSpecDefinitionDao = new PhysicalSpecDefinitionDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long specDefinitionId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalSpecDefinitionDao.delete(specDefinitionId);
+  }
+
+  @Test
+  public void findForSpecificationTest() throws Exception {
+    // Arrange
+    PhysicalSpecDefinitionDao physicalSpecDefinitionDao = new PhysicalSpecDefinitionDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long specificationId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalSpecDefinitionDao.findForSpecification(specificationId);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    PhysicalSpecDefinitionDao physicalSpecDefinitionDao = new PhysicalSpecDefinitionDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long specDefinitionId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalSpecDefinitionDao.getById(specDefinitionId);
+  }
+
+  @Test
+  public void markExistingActiveAsDeprecatedTest() throws Exception {
+    // Arrange
+    PhysicalSpecDefinitionDao physicalSpecDefinitionDao = new PhysicalSpecDefinitionDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long specificationId = 1L;
+    String userName = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalSpecDefinitionDao.markExistingActiveAsDeprecated(specificationId, userName);
+  }
+
+  @Test
+  public void updateStatusTest() throws Exception {
+    // Arrange
+    PhysicalSpecDefinitionDao physicalSpecDefinitionDao = new PhysicalSpecDefinitionDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long specDefinitionId = 1L;
+    ReleaseLifecycleStatus newStatus = ReleaseLifecycleStatus.DRAFT;
+    String userName = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalSpecDefinitionDao.updateStatus(specDefinitionId, newStatus, userName);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/physical_specification_definition/PhysicalSpecDefinitionFieldDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/physical_specification_definition/PhysicalSpecDefinitionFieldDaoTest.java
@@ -1,0 +1,105 @@
+package com.khartec.waltz.data.physical_specification_definition;
+
+import com.khartec.waltz.model.physical_specification_definition.ImmutablePhysicalSpecDefinitionField;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class PhysicalSpecDefinitionFieldDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void PhysicalSpecDefinitionFieldDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new PhysicalSpecDefinitionFieldDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    PhysicalSpecDefinitionFieldDao physicalSpecDefinitionFieldDao = new PhysicalSpecDefinitionFieldDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutablePhysicalSpecDefinitionField definitionField = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    physicalSpecDefinitionFieldDao.create(definitionField);
+  }
+
+  @Test
+  public void deleteForSpecDefinitionTest() throws Exception {
+    // Arrange
+    PhysicalSpecDefinitionFieldDao physicalSpecDefinitionFieldDao = new PhysicalSpecDefinitionFieldDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long specDefinitionId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalSpecDefinitionFieldDao.deleteForSpecDefinition(specDefinitionId);
+  }
+
+  @Test
+  public void deleteTest() throws Exception {
+    // Arrange
+    PhysicalSpecDefinitionFieldDao physicalSpecDefinitionFieldDao = new PhysicalSpecDefinitionFieldDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long specDefinitionFieldId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalSpecDefinitionFieldDao.delete(specDefinitionFieldId);
+  }
+
+  @Test
+  public void findForSpecDefinitionTest() throws Exception {
+    // Arrange
+    PhysicalSpecDefinitionFieldDao physicalSpecDefinitionFieldDao = new PhysicalSpecDefinitionFieldDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long specDefinitionId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalSpecDefinitionFieldDao.findForSpecDefinition(specDefinitionId);
+  }
+
+  @Test
+  public void updateDescriptionTest() throws Exception {
+    // Arrange
+    PhysicalSpecDefinitionFieldDao physicalSpecDefinitionFieldDao = new PhysicalSpecDefinitionFieldDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long fieldId = 1L;
+    String description = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalSpecDefinitionFieldDao.updateDescription(fieldId, description);
+  }
+
+  @Test
+  public void updateLogicalDataElementTest() throws Exception {
+    // Arrange
+    PhysicalSpecDefinitionFieldDao physicalSpecDefinitionFieldDao = new PhysicalSpecDefinitionFieldDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long fieldId = 1L;
+    Long logicalDataElementId = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalSpecDefinitionFieldDao.updateLogicalDataElement(fieldId, logicalDataElementId);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/physical_specification_definition/PhysicalSpecDefinitionSampleFileDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/physical_specification_definition/PhysicalSpecDefinitionSampleFileDaoTest.java
@@ -1,0 +1,79 @@
+package com.khartec.waltz.data.physical_specification_definition;
+
+import com.khartec.waltz.model.physical_specification_definition.ImmutablePhysicalSpecDefinitionSampleFile;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class PhysicalSpecDefinitionSampleFileDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void PhysicalSpecDefinitionSampleFileDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new PhysicalSpecDefinitionSampleFileDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    PhysicalSpecDefinitionSampleFileDao physicalSpecDefinitionSampleFileDao = new PhysicalSpecDefinitionSampleFileDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutablePhysicalSpecDefinitionSampleFile sampleFile = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    physicalSpecDefinitionSampleFileDao.create(sampleFile);
+  }
+
+  @Test
+  public void deleteForSpecDefinitionTest() throws Exception {
+    // Arrange
+    PhysicalSpecDefinitionSampleFileDao physicalSpecDefinitionSampleFileDao = new PhysicalSpecDefinitionSampleFileDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long specDefinitionId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalSpecDefinitionSampleFileDao.deleteForSpecDefinition(specDefinitionId);
+  }
+
+  @Test
+  public void deleteTest() throws Exception {
+    // Arrange
+    PhysicalSpecDefinitionSampleFileDao physicalSpecDefinitionSampleFileDao = new PhysicalSpecDefinitionSampleFileDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long specDefinitionSampleFileId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalSpecDefinitionSampleFileDao.delete(specDefinitionSampleFileId);
+  }
+
+  @Test
+  public void findForSpecDefinitionTest() throws Exception {
+    // Arrange
+    PhysicalSpecDefinitionSampleFileDao physicalSpecDefinitionSampleFileDao = new PhysicalSpecDefinitionSampleFileDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long specDefinitionId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    physicalSpecDefinitionSampleFileDao.findForSpecDefinition(specDefinitionId);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/physical_specification_definition/PhysicalSpecDefnFieldIdSelectorFactoryTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/physical_specification_definition/PhysicalSpecDefnFieldIdSelectorFactoryTest.java
@@ -1,0 +1,23 @@
+package com.khartec.waltz.data.physical_specification_definition;
+
+import com.khartec.waltz.model.ImmutableIdSelectionOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class PhysicalSpecDefnFieldIdSelectorFactoryTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void applyTest() throws Exception {
+    // Arrange
+    PhysicalSpecDefnFieldIdSelectorFactory physicalSpecDefnFieldIdSelectorFactory = new PhysicalSpecDefnFieldIdSelectorFactory();
+    ImmutableIdSelectionOptions options = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    physicalSpecDefnFieldIdSelectorFactory.apply(options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/physical_specification_definition/PhysicalSpecDefnIdSelectorFactoryTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/physical_specification_definition/PhysicalSpecDefnIdSelectorFactoryTest.java
@@ -1,0 +1,23 @@
+package com.khartec.waltz.data.physical_specification_definition;
+
+import com.khartec.waltz.model.ImmutableIdSelectionOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class PhysicalSpecDefnIdSelectorFactoryTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void applyTest() throws Exception {
+    // Arrange
+    PhysicalSpecDefnIdSelectorFactory physicalSpecDefnIdSelectorFactory = new PhysicalSpecDefnIdSelectorFactory();
+    ImmutableIdSelectionOptions options = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    physicalSpecDefnIdSelectorFactory.apply(options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/rating_scheme/RatingSchemeDAOTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/rating_scheme/RatingSchemeDAOTest.java
@@ -1,0 +1,75 @@
+package com.khartec.waltz.data.rating_scheme;
+
+import org.jooq.Condition;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.powermock.reflect.Whitebox;
+
+import static org.junit.Assert.assertEquals;
+
+public class RatingSchemeDAOTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void RatingSchemeDAOTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new RatingSchemeDAO(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void fetchItemsTest() throws Exception {
+    // Arrange
+    RatingSchemeDAO ratingSchemeDAO = new RatingSchemeDAO(new DefaultDSLContext(new DefaultConfiguration()));
+    Condition itemCondition = Whitebox.newInstance(Condition.class);
+
+    // Act and Assert
+    thrown.expect(ClassCastException.class);
+    ratingSchemeDAO.fetchItems(itemCondition);
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    RatingSchemeDAO ratingSchemeDAO = new RatingSchemeDAO(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    ratingSchemeDAO.findAll();
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    RatingSchemeDAO ratingSchemeDAO = new RatingSchemeDAO(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    ratingSchemeDAO.getById(id);
+  }
+
+  @Test
+  public void getRagNameByIdTest() throws Exception {
+    // Arrange
+    RatingSchemeDAO ratingSchemeDAO = new RatingSchemeDAO(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    ratingSchemeDAO.getRagNameById(id);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/roadmap/RoadmapDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/roadmap/RoadmapDaoTest.java
@@ -1,0 +1,149 @@
+package com.khartec.waltz.data.roadmap;
+
+import com.khartec.waltz.model.EntityLifecycleStatus;
+import com.khartec.waltz.model.ImmutableEntityReference;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class RoadmapDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void RoadmapDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new RoadmapDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createRoadmapTest() throws Exception {
+    // Arrange
+    RoadmapDao roadmapDao = new RoadmapDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String name = "aaaaa";
+    long ratingSchemeId = 1L;
+    ImmutableEntityReference columnType = null;
+    ImmutableEntityReference rowType = null;
+    String userId = "kaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    roadmapDao.createRoadmap(name, ratingSchemeId, columnType, rowType, userId);
+  }
+
+  @Test
+  public void findAllActiveTest() throws Exception {
+    // Arrange
+    RoadmapDao roadmapDao = new RoadmapDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    roadmapDao.findAllActive();
+  }
+
+  @Test
+  public void findAllRoadmapsAndScenariosTest() throws Exception {
+    // Arrange
+    RoadmapDao roadmapDao = new RoadmapDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    roadmapDao.findAllRoadmapsAndScenarios();
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    RoadmapDao roadmapDao = new RoadmapDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    roadmapDao.findAll();
+  }
+
+  @Test
+  public void findRoadmapsAndScenariosByFormalRelationshipTest() throws Exception {
+    // Arrange
+    RoadmapDao roadmapDao = new RoadmapDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference relatedEntity = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    roadmapDao.findRoadmapsAndScenariosByFormalRelationship(relatedEntity);
+  }
+
+  @Test
+  public void findRoadmapsAndScenariosByRatedEntityTest() throws Exception {
+    // Arrange
+    RoadmapDao roadmapDao = new RoadmapDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ratedEntity = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    roadmapDao.findRoadmapsAndScenariosByRatedEntity(ratedEntity);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    RoadmapDao roadmapDao = new RoadmapDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    roadmapDao.getById(id);
+  }
+
+  @Test
+  public void updateDescriptionTest() throws Exception {
+    // Arrange
+    RoadmapDao roadmapDao = new RoadmapDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+    String newValue = "aaaaa";
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    roadmapDao.updateDescription(id, newValue, userId);
+  }
+
+  @Test
+  public void updateLifecycleStatusTest() throws Exception {
+    // Arrange
+    RoadmapDao roadmapDao = new RoadmapDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+    EntityLifecycleStatus newValue = EntityLifecycleStatus.ACTIVE;
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    roadmapDao.updateLifecycleStatus(id, newValue, userId);
+  }
+
+  @Test
+  public void updateNameTest() throws Exception {
+    // Arrange
+    RoadmapDao roadmapDao = new RoadmapDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+    String newValue = "aaaaa";
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    roadmapDao.updateName(id, newValue, userId);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/roadmap/RoadmapIdSelectorFactoryTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/roadmap/RoadmapIdSelectorFactoryTest.java
@@ -1,0 +1,23 @@
+package com.khartec.waltz.data.roadmap;
+
+import com.khartec.waltz.model.ImmutableIdSelectionOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class RoadmapIdSelectorFactoryTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void applyTest() throws Exception {
+    // Arrange
+    RoadmapIdSelectorFactory roadmapIdSelectorFactory = new RoadmapIdSelectorFactory();
+    ImmutableIdSelectionOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    roadmapIdSelectorFactory.apply(options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/roadmap/RoadmapSearchDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/roadmap/RoadmapSearchDaoTest.java
@@ -1,0 +1,36 @@
+package com.khartec.waltz.data.roadmap;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class RoadmapSearchDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void RoadmapSearchDaoTest() throws Exception {
+    // Arrange
+    RoadmapDao roadmapDao = new RoadmapDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act
+    new RoadmapSearchDao(roadmapDao);
+  }
+
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    RoadmapSearchDao roadmapSearchDao = new RoadmapSearchDao(
+        new RoadmapDao(new DefaultDSLContext(new DefaultConfiguration())));
+    String query = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    roadmapSearchDao.search(query, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/role/RoleDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/role/RoleDaoTest.java
@@ -1,0 +1,52 @@
+package com.khartec.waltz.data.role;
+
+import com.khartec.waltz.schema.tables.records.RoleRecord;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class RoleDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void RoleDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new RoleDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    RoleDao roleDao = new RoleDao(new DefaultDSLContext(new DefaultConfiguration()));
+    RoleRecord role = new RoleRecord();
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    roleDao.create(role);
+  }
+
+  @Test
+  public void findAllRolesTest() throws Exception {
+    // Arrange
+    RoleDao roleDao = new RoleDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    roleDao.findAllRoles();
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/scenario/ScenarioAxisItemDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/scenario/ScenarioAxisItemDaoTest.java
@@ -1,0 +1,117 @@
+package com.khartec.waltz.data.scenario;
+
+import com.khartec.waltz.model.AxisOrientation;
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.scenario.ImmutableCloneScenarioCommand;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class ScenarioAxisItemDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void ScenarioAxisItemDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new ScenarioAxisItemDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void addTest() throws Exception {
+    // Arrange
+    ScenarioAxisItemDao scenarioAxisItemDao = new ScenarioAxisItemDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long scenarioId = 1L;
+    AxisOrientation orientation = AxisOrientation.ROW;
+    ImmutableEntityReference domainItem = null;
+    Integer position = new Integer(1);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    scenarioAxisItemDao.add(scenarioId, orientation, domainItem, position);
+  }
+
+  @Test
+  public void cloneItemsTest() throws Exception {
+    // Arrange
+    ScenarioAxisItemDao scenarioAxisItemDao = new ScenarioAxisItemDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableCloneScenarioCommand command = null;
+    Long clonedScenarioId = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    scenarioAxisItemDao.cloneItems(command, clonedScenarioId);
+  }
+
+  @Test
+  public void findForScenarioAndOrientationTest() throws Exception {
+    // Arrange
+    ScenarioAxisItemDao scenarioAxisItemDao = new ScenarioAxisItemDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long scenarioId = 1L;
+    AxisOrientation orientation = AxisOrientation.ROW;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    scenarioAxisItemDao.findForScenarioAndOrientation(scenarioId, orientation);
+  }
+
+  @Test
+  public void findForScenarioIdTest() throws Exception {
+    // Arrange
+    ScenarioAxisItemDao scenarioAxisItemDao = new ScenarioAxisItemDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long scenarioId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    scenarioAxisItemDao.findForScenarioId(scenarioId);
+  }
+
+  @Test
+  public void removeTest() throws Exception {
+    // Arrange
+    ScenarioAxisItemDao scenarioAxisItemDao = new ScenarioAxisItemDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long scenarioId = 1L;
+    AxisOrientation orientation = AxisOrientation.ROW;
+    ImmutableEntityReference domainItem = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    scenarioAxisItemDao.remove(scenarioId, orientation, domainItem);
+  }
+
+  @Test
+  public void reorderTest() throws Exception {
+    // Arrange
+    ScenarioAxisItemDao scenarioAxisItemDao = new ScenarioAxisItemDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long scenarioId = 1L;
+    AxisOrientation orientation = AxisOrientation.ROW;
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    scenarioAxisItemDao.reorder(scenarioId, orientation, arrayList);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/scenario/ScenarioDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/scenario/ScenarioDaoTest.java
@@ -1,0 +1,172 @@
+package com.khartec.waltz.data.scenario;
+
+import com.khartec.waltz.model.EntityLifecycleStatus;
+import com.khartec.waltz.model.ReleaseLifecycleStatus;
+import com.khartec.waltz.model.scenario.ImmutableCloneScenarioCommand;
+import com.khartec.waltz.model.scenario.ScenarioType;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.time.LocalDate;
+
+import static org.junit.Assert.assertEquals;
+
+public class ScenarioDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void ScenarioDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new ScenarioDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void addTest() throws Exception {
+    // Arrange
+    ScenarioDao scenarioDao = new ScenarioDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long roadmapId = 1L;
+    String name = "aaaaa";
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    scenarioDao.add(roadmapId, name, userId);
+  }
+
+  @Test
+  public void cloneScenarioTest() throws Exception {
+    // Arrange
+    ScenarioDao scenarioDao = new ScenarioDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableCloneScenarioCommand command = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    scenarioDao.cloneScenario(command);
+  }
+
+  @Test
+  public void findForRoadmapIdTest() throws Exception {
+    // Arrange
+    ScenarioDao scenarioDao = new ScenarioDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long roadmapId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    scenarioDao.findForRoadmapId(roadmapId);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    ScenarioDao scenarioDao = new ScenarioDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    scenarioDao.getById(id);
+  }
+
+  @Test
+  public void removeScenarioTest() throws Exception {
+    // Arrange
+    ScenarioDao scenarioDao = new ScenarioDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long scenarioId = 1L;
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    scenarioDao.removeScenario(scenarioId, userId);
+  }
+
+  @Test
+  public void updateDescriptionTest() throws Exception {
+    // Arrange
+    ScenarioDao scenarioDao = new ScenarioDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long scenarioId = 1L;
+    String newValue = "aaaaa";
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    scenarioDao.updateDescription(scenarioId, newValue, userId);
+  }
+
+  @Test
+  public void updateEffectiveDateTest() throws Exception {
+    // Arrange
+    ScenarioDao scenarioDao = new ScenarioDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long scenarioId = 1L;
+    LocalDate newValue = null;
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    scenarioDao.updateEffectiveDate(scenarioId, newValue, userId);
+  }
+
+  @Test
+  public void updateEntityLifecycleStatusTest() throws Exception {
+    // Arrange
+    ScenarioDao scenarioDao = new ScenarioDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long scenarioId = 1L;
+    EntityLifecycleStatus newValue = EntityLifecycleStatus.ACTIVE;
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    scenarioDao.updateEntityLifecycleStatus(scenarioId, newValue, userId);
+  }
+
+  @Test
+  public void updateNameTest() throws Exception {
+    // Arrange
+    ScenarioDao scenarioDao = new ScenarioDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long scenarioId = 1L;
+    String newValue = "aaaaa";
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    scenarioDao.updateName(scenarioId, newValue, userId);
+  }
+
+  @Test
+  public void updateReleaseStatusTest() throws Exception {
+    // Arrange
+    ScenarioDao scenarioDao = new ScenarioDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long scenarioId = 1L;
+    ReleaseLifecycleStatus newValue = ReleaseLifecycleStatus.DRAFT;
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    scenarioDao.updateReleaseStatus(scenarioId, newValue, userId);
+  }
+
+  @Test
+  public void updateScenarioTypeTest() throws Exception {
+    // Arrange
+    ScenarioDao scenarioDao = new ScenarioDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long scenarioId = 1L;
+    ScenarioType newValue = ScenarioType.TARGET;
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    scenarioDao.updateScenarioType(scenarioId, newValue, userId);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/scenario/ScenarioRatingItemDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/scenario/ScenarioRatingItemDaoTest.java
@@ -1,0 +1,107 @@
+package com.khartec.waltz.data.scenario;
+
+import com.khartec.waltz.model.scenario.ImmutableCloneScenarioCommand;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class ScenarioRatingItemDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void ScenarioRatingItemDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new ScenarioRatingItemDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void addTest() throws Exception {
+    // Arrange
+    ScenarioRatingItemDao scenarioRatingItemDao = new ScenarioRatingItemDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long scenarioId = 1L;
+    long appId = 1L;
+    long columnId = 1L;
+    long rowId = 1L;
+    char rating = 'c';
+    String userId = "kaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    scenarioRatingItemDao.add(scenarioId, appId, columnId, rowId, rating, userId);
+  }
+
+  @Test
+  public void cloneItemsTest() throws Exception {
+    // Arrange
+    ScenarioRatingItemDao scenarioRatingItemDao = new ScenarioRatingItemDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableCloneScenarioCommand command = null;
+    Long clonedScenarioId = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    scenarioRatingItemDao.cloneItems(command, clonedScenarioId);
+  }
+
+  @Test
+  public void findForScenarioIdTest() throws Exception {
+    // Arrange
+    ScenarioRatingItemDao scenarioRatingItemDao = new ScenarioRatingItemDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long scenarioId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    scenarioRatingItemDao.findForScenarioId(scenarioId);
+  }
+
+  @Test
+  public void removeTest() throws Exception {
+    // Arrange
+    ScenarioRatingItemDao scenarioRatingItemDao = new ScenarioRatingItemDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long scenarioId = 1L;
+    long appId = 1L;
+    long columnId = 1L;
+    long rowId = 1L;
+    String userId = "akaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    scenarioRatingItemDao.remove(scenarioId, appId, columnId, rowId, userId);
+  }
+
+  @Test
+  public void updateRatingTest() throws Exception {
+    // Arrange
+    ScenarioRatingItemDao scenarioRatingItemDao = new ScenarioRatingItemDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long scenarioId = 1L;
+    long appId = 1L;
+    long columnId = 1L;
+    long rowId = 1L;
+    char rating = 'c';
+    String comment = "kaaaa";
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    scenarioRatingItemDao.updateRating(scenarioId, appId, columnId, rowId, rating, comment, userId);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/scheduled_job/ScheduledJobDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/scheduled_job/ScheduledJobDaoTest.java
@@ -1,0 +1,66 @@
+package com.khartec.waltz.data.scheduled_job;
+
+import com.khartec.waltz.model.scheduled_job.JobKey;
+import com.khartec.waltz.model.scheduled_job.JobLifecycleStatus;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class ScheduledJobDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void ScheduledJobDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new ScheduledJobDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void isJobRunnableTest() throws Exception {
+    // Arrange
+    ScheduledJobDao scheduledJobDao = new ScheduledJobDao(new DefaultDSLContext(new DefaultConfiguration()));
+    JobKey jobKey = JobKey.HIERARCHY_REBUILD_CHANGE_INITIATIVE;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    scheduledJobDao.isJobRunnable(jobKey);
+  }
+
+  @Test
+  public void markJobAsRunningTest() throws Exception {
+    // Arrange
+    ScheduledJobDao scheduledJobDao = new ScheduledJobDao(new DefaultDSLContext(new DefaultConfiguration()));
+    JobKey jobKey = JobKey.HIERARCHY_REBUILD_CHANGE_INITIATIVE;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    scheduledJobDao.markJobAsRunning(jobKey);
+  }
+
+  @Test
+  public void updateJobStatusTest() throws Exception {
+    // Arrange
+    ScheduledJobDao scheduledJobDao = new ScheduledJobDao(new DefaultDSLContext(new DefaultConfiguration()));
+    JobKey jobKey = JobKey.HIERARCHY_REBUILD_CHANGE_INITIATIVE;
+    JobLifecycleStatus newStatus = JobLifecycleStatus.RUNNABLE;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    scheduledJobDao.updateJobStatus(jobKey, newStatus);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/server_information/ServerInformationDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/server_information/ServerInformationDaoTest.java
@@ -1,0 +1,106 @@
+package com.khartec.waltz.data.server_information;
+
+import com.khartec.waltz.model.server_information.ServerInformation;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class ServerInformationDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void ServerInformationDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new ServerInformationDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void bulkSaveTest() throws Exception {
+    // Arrange
+    ServerInformationDao serverInformationDao = new ServerInformationDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<ServerInformation> arrayList = new ArrayList<ServerInformation>();
+    arrayList.add(null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    serverInformationDao.bulkSave(arrayList);
+  }
+
+  @Test
+  public void findByAppIdTest() throws Exception {
+    // Arrange
+    ServerInformationDao serverInformationDao = new ServerInformationDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long appId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    serverInformationDao.findByAppId(appId);
+  }
+
+  @Test
+  public void findByAssetCodeTest() throws Exception {
+    // Arrange
+    ServerInformationDao serverInformationDao = new ServerInformationDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    String assetCode = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    serverInformationDao.findByAssetCode(assetCode);
+  }
+
+  @Test
+  public void getByExternalIdTest() throws Exception {
+    // Arrange
+    ServerInformationDao serverInformationDao = new ServerInformationDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    String externalId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    serverInformationDao.getByExternalId(externalId);
+  }
+
+  @Test
+  public void getByHostnameTest() throws Exception {
+    // Arrange
+    ServerInformationDao serverInformationDao = new ServerInformationDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    String hostname = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    serverInformationDao.getByHostname(hostname);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    ServerInformationDao serverInformationDao = new ServerInformationDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    serverInformationDao.getById(id);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/server_information/search/MariaServerInformationSearchTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/server_information/search/MariaServerInformationSearchTest.java
@@ -1,0 +1,27 @@
+package com.khartec.waltz.data.server_information.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class MariaServerInformationSearchTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    MariaServerInformationSearch mariaServerInformationSearch = new MariaServerInformationSearch();
+    DefaultDSLContext dsl = new DefaultDSLContext(new DefaultConfiguration());
+    String query = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    mariaServerInformationSearch.search(dsl, query, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/server_information/search/PostgresServerInformationSearchTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/server_information/search/PostgresServerInformationSearchTest.java
@@ -1,0 +1,27 @@
+package com.khartec.waltz.data.server_information.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class PostgresServerInformationSearchTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    PostgresServerInformationSearch postgresServerInformationSearch = new PostgresServerInformationSearch();
+    DefaultDSLContext dsl = new DefaultDSLContext(new DefaultConfiguration());
+    String query = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    postgresServerInformationSearch.search(dsl, query, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/server_information/search/ServerInformationSearchDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/server_information/search/ServerInformationSearchDaoTest.java
@@ -1,0 +1,43 @@
+package com.khartec.waltz.data.server_information.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class ServerInformationSearchDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void ServerInformationSearchDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new ServerInformationSearchDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    ServerInformationSearchDao serverInformationSearchDao = new ServerInformationSearchDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    String terms = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    serverInformationSearchDao.search(terms, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/server_information/search/SqlServerServerInformationSearchTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/server_information/search/SqlServerServerInformationSearchTest.java
@@ -1,0 +1,27 @@
+package com.khartec.waltz.data.server_information.search;
+
+import com.khartec.waltz.model.entity_search.ImmutableEntitySearchOptions;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SqlServerServerInformationSearchTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void searchTest() throws Exception {
+    // Arrange
+    SqlServerServerInformationSearch sqlServerServerInformationSearch = new SqlServerServerInformationSearch();
+    DefaultDSLContext dsl = new DefaultDSLContext(new DefaultConfiguration());
+    String query = "aaaaa";
+    ImmutableEntitySearchOptions options = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    sqlServerServerInformationSearch.search(dsl, query, options);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/server_usage/ServerUsageDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/server_usage/ServerUsageDaoTest.java
@@ -1,0 +1,64 @@
+package com.khartec.waltz.data.server_usage;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class ServerUsageDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void ServerUsageDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new ServerUsageDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findByReferencedEntityTest() throws Exception {
+    // Arrange
+    ServerUsageDao serverUsageDao = new ServerUsageDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    serverUsageDao.findByReferencedEntity(ref);
+  }
+
+  @Test
+  public void findByServerIdTest() throws Exception {
+    // Arrange
+    ServerUsageDao serverUsageDao = new ServerUsageDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long serverId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    serverUsageDao.findByServerId(serverId);
+  }
+
+  @Test
+  public void findForEntityTest() throws Exception {
+    // Arrange
+    ServerUsageDao serverUsageDao = new ServerUsageDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    serverUsageDao.findForEntity(ref);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/settings/SettingsDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/settings/SettingsDaoTest.java
@@ -1,0 +1,51 @@
+package com.khartec.waltz.data.settings;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class SettingsDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void SettingsDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new SettingsDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    SettingsDao settingsDao = new SettingsDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    settingsDao.findAll();
+  }
+
+  @Test
+  public void getByNameTest() throws Exception {
+    // Arrange
+    SettingsDao settingsDao = new SettingsDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String name = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    settingsDao.getByName(name);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/shared_preference/SharedPreferenceDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/shared_preference/SharedPreferenceDaoTest.java
@@ -1,0 +1,68 @@
+package com.khartec.waltz.data.shared_preference;
+
+import com.khartec.waltz.model.shared_preference.ImmutableSharedPreference;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class SharedPreferenceDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void SharedPreferenceDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new SharedPreferenceDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findPreferencesByCategoryTest() throws Exception {
+    // Arrange
+    SharedPreferenceDao sharedPreferenceDao = new SharedPreferenceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    String category = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    sharedPreferenceDao.findPreferencesByCategory(category);
+  }
+
+  @Test
+  public void getPreferenceTest() throws Exception {
+    // Arrange
+    SharedPreferenceDao sharedPreferenceDao = new SharedPreferenceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    String key = "aaaaa";
+    String category = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    sharedPreferenceDao.getPreference(key, category);
+  }
+
+  @Test
+  public void savePreferenceTest() throws Exception {
+    // Arrange
+    SharedPreferenceDao sharedPreferenceDao = new SharedPreferenceDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableSharedPreference sharedPreference = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    sharedPreferenceDao.savePreference(sharedPreference);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/software_catalog/SoftwarePackageDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/software_catalog/SoftwarePackageDaoTest.java
@@ -1,0 +1,101 @@
+package com.khartec.waltz.data.software_catalog;
+
+import com.khartec.waltz.model.software_catalog.SoftwarePackage;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class SoftwarePackageDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void SoftwarePackageDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new SoftwarePackageDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void bulkStoreTest() throws Exception {
+    // Arrange
+    SoftwarePackageDao softwarePackageDao = new SoftwarePackageDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<SoftwarePackage> arrayList = new ArrayList<SoftwarePackage>();
+    arrayList.add(null);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    softwarePackageDao.bulkStore(arrayList);
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    SoftwarePackageDao softwarePackageDao = new SoftwarePackageDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    softwarePackageDao.findAll();
+  }
+
+  @Test
+  public void findByExternalIdsTest() throws Exception {
+    // Arrange
+    SoftwarePackageDao softwarePackageDao = new SoftwarePackageDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String[] externalIds = new String[]{"aaaaa", "aaaaa", "kaaaa"};
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    softwarePackageDao.findByExternalIds(externalIds);
+  }
+
+  @Test
+  public void findByIdsTest() throws Exception {
+    // Arrange
+    SoftwarePackageDao softwarePackageDao = new SoftwarePackageDao(new DefaultDSLContext(new DefaultConfiguration()));
+    Long resultLong = new Long(1L);
+    Long[] ids = new Long[]{resultLong, new Long(1L), resultLong};
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    softwarePackageDao.findByIds(ids);
+  }
+
+  @Test
+  public void findByIdsTest2() throws Exception {
+    // Arrange
+    SoftwarePackageDao softwarePackageDao = new SoftwarePackageDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    softwarePackageDao.findByIds(arrayList);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    SoftwarePackageDao softwarePackageDao = new SoftwarePackageDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    softwarePackageDao.getById(id);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/software_catalog/SoftwareUsageDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/software_catalog/SoftwareUsageDaoTest.java
@@ -1,0 +1,68 @@
+package com.khartec.waltz.data.software_catalog;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class SoftwareUsageDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void SoftwareUsageDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new SoftwareUsageDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findByAppIdsTest() throws Exception {
+    // Arrange
+    SoftwareUsageDao softwareUsageDao = new SoftwareUsageDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    softwareUsageDao.findByAppIds(arrayList);
+  }
+
+  @Test
+  public void findByAppIdsTest2() throws Exception {
+    // Arrange
+    SoftwareUsageDao softwareUsageDao = new SoftwareUsageDao(new DefaultDSLContext(new DefaultConfiguration()));
+    Long resultLong = new Long(1L);
+    Long[] appIds = new Long[]{resultLong, new Long(1L), resultLong};
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    softwareUsageDao.findByAppIds(appIds);
+  }
+
+  @Test
+  public void findBySoftwarePackageIdsTest() throws Exception {
+    // Arrange
+    SoftwareUsageDao softwareUsageDao = new SoftwareUsageDao(new DefaultDSLContext(new DefaultConfiguration()));
+    Long resultLong = new Long(1L);
+    Long[] softwarePackageIds = new Long[]{resultLong, new Long(1L), resultLong};
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    softwareUsageDao.findBySoftwarePackageIds(softwarePackageIds);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/source_data_rating/SourceDataRatingDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/source_data_rating/SourceDataRatingDaoTest.java
@@ -1,0 +1,41 @@
+package com.khartec.waltz.data.source_data_rating;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class SourceDataRatingDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void SourceDataRatingDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new SourceDataRatingDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    SourceDataRatingDao sourceDataRatingDao = new SourceDataRatingDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    sourceDataRatingDao.findAll();
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/static_panel/StaticPanelDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/static_panel/StaticPanelDaoTest.java
@@ -1,0 +1,74 @@
+package com.khartec.waltz.data.static_panel;
+
+import com.khartec.waltz.model.staticpanel.ImmutableStaticPanel;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class StaticPanelDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void StaticPanelDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new StaticPanelDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    StaticPanelDao staticPanelDao = new StaticPanelDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableStaticPanel panel = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    staticPanelDao.create(panel);
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    StaticPanelDao staticPanelDao = new StaticPanelDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    staticPanelDao.findAll();
+  }
+
+  @Test
+  public void findByGroupsTest() throws Exception {
+    // Arrange
+    StaticPanelDao staticPanelDao = new StaticPanelDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String[] groups = new String[]{"aaaaa", "aaaaa", "kaaaa"};
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    staticPanelDao.findByGroups(groups);
+  }
+
+  @Test
+  public void updateTest() throws Exception {
+    // Arrange
+    StaticPanelDao staticPanelDao = new StaticPanelDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableStaticPanel panel = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    staticPanelDao.update(panel);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/survey/SurveyInstanceDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/survey/SurveyInstanceDaoTest.java
@@ -1,0 +1,219 @@
+package com.khartec.waltz.data.survey;
+
+import com.khartec.waltz.model.survey.ImmutableSurveyInstance;
+import com.khartec.waltz.model.survey.ImmutableSurveyInstanceCreateCommand;
+import com.khartec.waltz.model.survey.SurveyInstanceStatus;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class SurveyInstanceDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void SurveyInstanceDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new SurveyInstanceDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void clearApprovedTest() throws Exception {
+    // Arrange
+    SurveyInstanceDao surveyInstanceDao = new SurveyInstanceDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long instanceId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyInstanceDao.clearApproved(instanceId);
+  }
+
+  @Test
+  public void createInstanceRecipientsTest() throws Exception {
+    // Arrange
+    SurveyInstanceDao surveyInstanceDao = new SurveyInstanceDao(new DefaultDSLContext(new DefaultConfiguration()));
+    Long instanceId = new Long(1L);
+    ArrayList<Long> arrayList = new ArrayList<Long>();
+    arrayList.add(new Long(1L));
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    surveyInstanceDao.createInstanceRecipients(instanceId, arrayList);
+  }
+
+  @Test
+  public void createPreviousVersionTest() throws Exception {
+    // Arrange
+    SurveyInstanceDao surveyInstanceDao = new SurveyInstanceDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableSurveyInstance currentInstance = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    surveyInstanceDao.createPreviousVersion(currentInstance);
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    SurveyInstanceDao surveyInstanceDao = new SurveyInstanceDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableSurveyInstanceCreateCommand command = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    surveyInstanceDao.create(command);
+  }
+
+  @Test
+  public void deleteForSurveyRunTest() throws Exception {
+    // Arrange
+    SurveyInstanceDao surveyInstanceDao = new SurveyInstanceDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long surveyRunId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyInstanceDao.deleteForSurveyRun(surveyRunId);
+  }
+
+  @Test
+  public void findCompletionRateForSurveyTemplateTest() throws Exception {
+    // Arrange
+    SurveyInstanceDao surveyInstanceDao = new SurveyInstanceDao(new DefaultDSLContext(new DefaultConfiguration()));
+    Long surveyTemplateId = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyInstanceDao.findCompletionRateForSurveyTemplate(surveyTemplateId);
+  }
+
+  @Test
+  public void findForRecipientTest() throws Exception {
+    // Arrange
+    SurveyInstanceDao surveyInstanceDao = new SurveyInstanceDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long personId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyInstanceDao.findForRecipient(personId);
+  }
+
+  @Test
+  public void findForSurveyRunTest() throws Exception {
+    // Arrange
+    SurveyInstanceDao surveyInstanceDao = new SurveyInstanceDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long surveyRunId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyInstanceDao.findForSurveyRun(surveyRunId);
+  }
+
+  @Test
+  public void findPreviousVersionsForInstanceTest() throws Exception {
+    // Arrange
+    SurveyInstanceDao surveyInstanceDao = new SurveyInstanceDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long instanceId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyInstanceDao.findPreviousVersionsForInstance(instanceId);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    SurveyInstanceDao surveyInstanceDao = new SurveyInstanceDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyInstanceDao.getById(id);
+  }
+
+  @Test
+  public void getCompletionRateForSurveyRunTest() throws Exception {
+    // Arrange
+    SurveyInstanceDao surveyInstanceDao = new SurveyInstanceDao(new DefaultDSLContext(new DefaultConfiguration()));
+    Long surveyRunId = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyInstanceDao.getCompletionRateForSurveyRun(surveyRunId);
+  }
+
+  @Test
+  public void markApprovedTest() throws Exception {
+    // Arrange
+    SurveyInstanceDao surveyInstanceDao = new SurveyInstanceDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long instanceId = 1L;
+    String userName = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyInstanceDao.markApproved(instanceId, userName);
+  }
+
+  @Test
+  public void updateDueDateForSurveyRunTest() throws Exception {
+    // Arrange
+    SurveyInstanceDao surveyInstanceDao = new SurveyInstanceDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long surveyRunId = 1L;
+    LocalDate newDueDate = null;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyInstanceDao.updateDueDateForSurveyRun(surveyRunId, newDueDate);
+  }
+
+  @Test
+  public void updateDueDateTest() throws Exception {
+    // Arrange
+    SurveyInstanceDao surveyInstanceDao = new SurveyInstanceDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long instanceId = 1L;
+    LocalDate newDueDate = null;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyInstanceDao.updateDueDate(instanceId, newDueDate);
+  }
+
+  @Test
+  public void updateStatusTest() throws Exception {
+    // Arrange
+    SurveyInstanceDao surveyInstanceDao = new SurveyInstanceDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long instanceId = 1L;
+    SurveyInstanceStatus newStatus = SurveyInstanceStatus.NOT_STARTED;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyInstanceDao.updateStatus(instanceId, newStatus);
+  }
+
+  @Test
+  public void updateSubmittedTest() throws Exception {
+    // Arrange
+    SurveyInstanceDao surveyInstanceDao = new SurveyInstanceDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long instanceId = 1L;
+    String userName = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyInstanceDao.updateSubmitted(instanceId, userName);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/survey/SurveyInstanceRecipientDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/survey/SurveyInstanceRecipientDaoTest.java
@@ -1,0 +1,92 @@
+package com.khartec.waltz.data.survey;
+
+import com.khartec.waltz.model.survey.ImmutableSurveyInstanceRecipientCreateCommand;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class SurveyInstanceRecipientDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void SurveyInstanceRecipientDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new SurveyInstanceRecipientDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    SurveyInstanceRecipientDao surveyInstanceRecipientDao = new SurveyInstanceRecipientDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableSurveyInstanceRecipientCreateCommand command = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    surveyInstanceRecipientDao.create(command);
+  }
+
+  @Test
+  public void deleteForSurveyRunTest() throws Exception {
+    // Arrange
+    SurveyInstanceRecipientDao surveyInstanceRecipientDao = new SurveyInstanceRecipientDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long surveyRunId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyInstanceRecipientDao.deleteForSurveyRun(surveyRunId);
+  }
+
+  @Test
+  public void deleteTest() throws Exception {
+    // Arrange
+    SurveyInstanceRecipientDao surveyInstanceRecipientDao = new SurveyInstanceRecipientDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long surveyInstanceRecipientId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyInstanceRecipientDao.delete(surveyInstanceRecipientId);
+  }
+
+  @Test
+  public void findForSurveyInstanceTest() throws Exception {
+    // Arrange
+    SurveyInstanceRecipientDao surveyInstanceRecipientDao = new SurveyInstanceRecipientDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long surveyInstanceId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyInstanceRecipientDao.findForSurveyInstance(surveyInstanceId);
+  }
+
+  @Test
+  public void isPersonInstanceRecipientTest() throws Exception {
+    // Arrange
+    SurveyInstanceRecipientDao surveyInstanceRecipientDao = new SurveyInstanceRecipientDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long personId = 1L;
+    long surveyInstanceId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyInstanceRecipientDao.isPersonInstanceRecipient(personId, surveyInstanceId);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/survey/SurveyQuestionDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/survey/SurveyQuestionDaoTest.java
@@ -1,0 +1,97 @@
+package com.khartec.waltz.data.survey;
+
+import com.khartec.waltz.model.survey.ImmutableSurveyQuestion;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class SurveyQuestionDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void SurveyQuestionDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new SurveyQuestionDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    SurveyQuestionDao surveyQuestionDao = new SurveyQuestionDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableSurveyQuestion surveyQuestion = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    surveyQuestionDao.create(surveyQuestion);
+  }
+
+  @Test
+  public void deleteTest() throws Exception {
+    // Arrange
+    SurveyQuestionDao surveyQuestionDao = new SurveyQuestionDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long questionId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyQuestionDao.delete(questionId);
+  }
+
+  @Test
+  public void findForSurveyInstanceTest() throws Exception {
+    // Arrange
+    SurveyQuestionDao surveyQuestionDao = new SurveyQuestionDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long surveyInstanceId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyQuestionDao.findForSurveyInstance(surveyInstanceId);
+  }
+
+  @Test
+  public void findForSurveyRunTest() throws Exception {
+    // Arrange
+    SurveyQuestionDao surveyQuestionDao = new SurveyQuestionDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long surveyRunId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyQuestionDao.findForSurveyRun(surveyRunId);
+  }
+
+  @Test
+  public void findForTemplateTest() throws Exception {
+    // Arrange
+    SurveyQuestionDao surveyQuestionDao = new SurveyQuestionDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long templateId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyQuestionDao.findForTemplate(templateId);
+  }
+
+  @Test
+  public void updateTest() throws Exception {
+    // Arrange
+    SurveyQuestionDao surveyQuestionDao = new SurveyQuestionDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableSurveyQuestion surveyQuestion = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    surveyQuestionDao.update(surveyQuestion);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/survey/SurveyQuestionDropdownEntryDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/survey/SurveyQuestionDropdownEntryDaoTest.java
@@ -1,0 +1,60 @@
+package com.khartec.waltz.data.survey;
+
+import com.khartec.waltz.model.survey.SurveyQuestionDropdownEntry;
+import org.jooq.exception.DataAccessException;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class SurveyQuestionDropdownEntryDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void SurveyQuestionDropdownEntryDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new SurveyQuestionDropdownEntryDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findForQuestionTest() throws Exception {
+    // Arrange
+    SurveyQuestionDropdownEntryDao surveyQuestionDropdownEntryDao = new SurveyQuestionDropdownEntryDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long questionId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyQuestionDropdownEntryDao.findForQuestion(questionId);
+  }
+
+  @Test
+  public void saveEntriesTest() throws Exception {
+    // Arrange
+    SurveyQuestionDropdownEntryDao surveyQuestionDropdownEntryDao = new SurveyQuestionDropdownEntryDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long questionId = 1L;
+    ArrayList<SurveyQuestionDropdownEntry> arrayList = new ArrayList<SurveyQuestionDropdownEntry>();
+    arrayList.add(null);
+
+    // Act and Assert
+    thrown.expect(DataAccessException.class);
+    surveyQuestionDropdownEntryDao.saveEntries(questionId, arrayList);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/survey/SurveyQuestionResponseDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/survey/SurveyQuestionResponseDaoTest.java
@@ -1,0 +1,80 @@
+package com.khartec.waltz.data.survey;
+
+import com.khartec.waltz.model.survey.ImmutableSurveyInstanceQuestionResponse;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class SurveyQuestionResponseDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void SurveyQuestionResponseDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new SurveyQuestionResponseDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void cloneResponsesTest() throws Exception {
+    // Arrange
+    SurveyQuestionResponseDao surveyQuestionResponseDao = new SurveyQuestionResponseDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long sourceSurveyInstanceId = 1L;
+    long targetSurveyInstanceId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyQuestionResponseDao.cloneResponses(sourceSurveyInstanceId, targetSurveyInstanceId);
+  }
+
+  @Test
+  public void findForInstanceTest() throws Exception {
+    // Arrange
+    SurveyQuestionResponseDao surveyQuestionResponseDao = new SurveyQuestionResponseDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long surveyInstanceId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyQuestionResponseDao.findForInstance(surveyInstanceId);
+  }
+
+  @Test
+  public void findForSurveyRunTest() throws Exception {
+    // Arrange
+    SurveyQuestionResponseDao surveyQuestionResponseDao = new SurveyQuestionResponseDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    long surveyRunId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyQuestionResponseDao.findForSurveyRun(surveyRunId);
+  }
+
+  @Test
+  public void saveResponseTest() throws Exception {
+    // Arrange
+    SurveyQuestionResponseDao surveyQuestionResponseDao = new SurveyQuestionResponseDao(
+        new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableSurveyInstanceQuestionResponse response = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    surveyQuestionResponseDao.saveResponse(response);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/survey/SurveyRunDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/survey/SurveyRunDaoTest.java
@@ -1,0 +1,127 @@
+package com.khartec.waltz.data.survey;
+
+import com.khartec.waltz.model.survey.ImmutableSurveyRunChangeCommand;
+import com.khartec.waltz.model.survey.ImmutableSurveyRunCreateCommand;
+import com.khartec.waltz.model.survey.SurveyRunStatus;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.time.LocalDate;
+
+import static org.junit.Assert.assertEquals;
+
+public class SurveyRunDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void SurveyRunDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new SurveyRunDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    SurveyRunDao surveyRunDao = new SurveyRunDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long ownerId = 1L;
+    ImmutableSurveyRunCreateCommand command = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    surveyRunDao.create(ownerId, command);
+  }
+
+  @Test
+  public void findByTemplateIdTest() throws Exception {
+    // Arrange
+    SurveyRunDao surveyRunDao = new SurveyRunDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long templateId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyRunDao.findByTemplateId(templateId);
+  }
+
+  @Test
+  public void findForRecipientTest() throws Exception {
+    // Arrange
+    SurveyRunDao surveyRunDao = new SurveyRunDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long personId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyRunDao.findForRecipient(personId);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    SurveyRunDao surveyRunDao = new SurveyRunDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyRunDao.getById(id);
+  }
+
+  @Test
+  public void issueTest() throws Exception {
+    // Arrange
+    SurveyRunDao surveyRunDao = new SurveyRunDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long surveyRunId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyRunDao.issue(surveyRunId);
+  }
+
+  @Test
+  public void updateDueDateTest() throws Exception {
+    // Arrange
+    SurveyRunDao surveyRunDao = new SurveyRunDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long surveyRunId = 1L;
+    LocalDate newDueDate = null;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyRunDao.updateDueDate(surveyRunId, newDueDate);
+  }
+
+  @Test
+  public void updateStatusTest() throws Exception {
+    // Arrange
+    SurveyRunDao surveyRunDao = new SurveyRunDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long surveyRunId = 1L;
+    SurveyRunStatus newStatus = SurveyRunStatus.DRAFT;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyRunDao.updateStatus(surveyRunId, newStatus);
+  }
+
+  @Test
+  public void updateTest() throws Exception {
+    // Arrange
+    SurveyRunDao surveyRunDao = new SurveyRunDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long surveyRunId = 1L;
+    ImmutableSurveyRunChangeCommand command = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    surveyRunDao.update(surveyRunId, command);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/survey/SurveyTemplateDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/survey/SurveyTemplateDaoTest.java
@@ -1,0 +1,89 @@
+package com.khartec.waltz.data.survey;
+
+import com.khartec.waltz.model.ReleaseLifecycleStatus;
+import com.khartec.waltz.model.survey.ImmutableSurveyTemplate;
+import com.khartec.waltz.model.survey.ImmutableSurveyTemplateChangeCommand;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class SurveyTemplateDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void SurveyTemplateDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new SurveyTemplateDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    SurveyTemplateDao surveyTemplateDao = new SurveyTemplateDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableSurveyTemplate surveyTemplate = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    surveyTemplateDao.create(surveyTemplate);
+  }
+
+  @Test
+  public void findAllTest() throws Exception {
+    // Arrange
+    SurveyTemplateDao surveyTemplateDao = new SurveyTemplateDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long ownerId = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyTemplateDao.findAll(ownerId);
+  }
+
+  @Test
+  public void getByIdTest() throws Exception {
+    // Arrange
+    SurveyTemplateDao surveyTemplateDao = new SurveyTemplateDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyTemplateDao.getById(id);
+  }
+
+  @Test
+  public void updateStatusTest() throws Exception {
+    // Arrange
+    SurveyTemplateDao surveyTemplateDao = new SurveyTemplateDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long templateId = 1L;
+    ReleaseLifecycleStatus newStatus = ReleaseLifecycleStatus.DRAFT;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    surveyTemplateDao.updateStatus(templateId, newStatus);
+  }
+
+  @Test
+  public void updateTest() throws Exception {
+    // Arrange
+    SurveyTemplateDao surveyTemplateDao = new SurveyTemplateDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableSurveyTemplateChangeCommand command = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    surveyTemplateDao.update(command);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/svg/SvgDiagramDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/svg/SvgDiagramDaoTest.java
@@ -1,0 +1,39 @@
+package com.khartec.waltz.data.svg;
+
+import com.khartec.waltz.model.svg.SvgDiagram;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class SvgDiagramDaoTest {
+  @Test
+  public void SvgDiagramDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new SvgDiagramDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findByGroupsTest() throws Exception {
+    // Arrange
+    SvgDiagramDao svgDiagramDao = new SvgDiagramDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String[] groups = new String[]{"aaaaa", "aaaaa", "kaaaa"};
+
+    // Act
+    List<SvgDiagram> actual = svgDiagramDao.findByGroups(groups);
+
+    // Assert
+    assertEquals(null, actual);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/system/job_log/JobLogDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/system/job_log/JobLogDaoTest.java
@@ -1,0 +1,40 @@
+package com.khartec.waltz.data.system.job_log;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class JobLogDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void JobLogDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new JobLogDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findLatestSuccessfulTest() throws Exception {
+    // Arrange
+    JobLogDao jobLogDao = new JobLogDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    jobLogDao.findLatestSuccessful();
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/tag/TagDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/tag/TagDaoTest.java
@@ -1,0 +1,124 @@
+package com.khartec.waltz.data.tag;
+
+import com.khartec.waltz.model.EntityKind;
+import com.khartec.waltz.model.ImmutableEntityReference;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class TagDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void TagDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new TagDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTagTest() throws Exception {
+    // Arrange
+    TagDao tagDao = new TagDao(new DefaultDSLContext(new DefaultConfiguration()));
+    EntityKind targetKind = EntityKind.ACTOR;
+    String tag = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    tagDao.createTag(targetKind, tag);
+  }
+
+  @Test
+  public void createTagUsageTest() throws Exception {
+    // Arrange
+    TagDao tagDao = new TagDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+    String username = "aaaaa";
+    Long tagId = new Long(1L);
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    tagDao.createTagUsage(ref, username, tagId);
+  }
+
+  @Test
+  public void findAllTagsTest() throws Exception {
+    // Arrange
+    TagDao tagDao = new TagDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    tagDao.findAllTags();
+  }
+
+  @Test
+  public void findByTagTest() throws Exception {
+    // Arrange
+    TagDao tagDao = new TagDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String tag = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    tagDao.findByTag(tag);
+  }
+
+  @Test
+  public void findTagByNameAndTargetKindTest() throws Exception {
+    // Arrange
+    TagDao tagDao = new TagDao(new DefaultDSLContext(new DefaultConfiguration()));
+    EntityKind entityKind = EntityKind.ACTOR;
+    String tagName = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    tagDao.findTagByNameAndTargetKind(entityKind, tagName);
+  }
+
+  @Test
+  public void findTagsForEntityKindTest() throws Exception {
+    // Arrange
+    TagDao tagDao = new TagDao(new DefaultDSLContext(new DefaultConfiguration()));
+    EntityKind entityKind = EntityKind.ACTOR;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    tagDao.findTagsForEntityKind(entityKind);
+  }
+
+  @Test
+  public void findTagsForEntityReferenceTest() throws Exception {
+    // Arrange
+    TagDao tagDao = new TagDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    tagDao.findTagsForEntityReference(ref);
+  }
+
+  @Test
+  public void removeTagUsageTest() throws Exception {
+    // Arrange
+    TagDao tagDao = new TagDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+    String tagToRemove = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    tagDao.removeTagUsage(ref, tagToRemove);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/taxonomy_management/TaxonomyChangeDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/taxonomy_management/TaxonomyChangeDaoTest.java
@@ -1,0 +1,90 @@
+package com.khartec.waltz.data.taxonomy_management;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.taxonomy_management.ImmutableTaxonomyChangeCommand;
+import com.khartec.waltz.model.taxonomy_management.TaxonomyChangeLifecycleStatus;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class TaxonomyChangeDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void TaxonomyChangeDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new TaxonomyChangeDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createCommandTest() throws Exception {
+    // Arrange
+    TaxonomyChangeDao taxonomyChangeDao = new TaxonomyChangeDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableTaxonomyChangeCommand cmd = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    taxonomyChangeDao.createCommand(cmd);
+  }
+
+  @Test
+  public void findChangesByDomainAndStatusTest() throws Exception {
+    // Arrange
+    TaxonomyChangeDao taxonomyChangeDao = new TaxonomyChangeDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference domain = null;
+    TaxonomyChangeLifecycleStatus status = TaxonomyChangeLifecycleStatus.DRAFT;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    taxonomyChangeDao.findChangesByDomainAndStatus(domain, status);
+  }
+
+  @Test
+  public void getDraftCommandByIdTest() throws Exception {
+    // Arrange
+    TaxonomyChangeDao taxonomyChangeDao = new TaxonomyChangeDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    taxonomyChangeDao.getDraftCommandById(id);
+  }
+
+  @Test
+  public void removeByIdTest() throws Exception {
+    // Arrange
+    TaxonomyChangeDao taxonomyChangeDao = new TaxonomyChangeDao(new DefaultDSLContext(new DefaultConfiguration()));
+    long id = 1L;
+    String userId = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    taxonomyChangeDao.removeById(id, userId);
+  }
+
+  @Test
+  public void updateTest() throws Exception {
+    // Arrange
+    TaxonomyChangeDao taxonomyChangeDao = new TaxonomyChangeDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableTaxonomyChangeCommand cmd = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    taxonomyChangeDao.update(cmd);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/thumbnail/ThumbnailDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/thumbnail/ThumbnailDaoTest.java
@@ -1,0 +1,75 @@
+package com.khartec.waltz.data.thumbnail;
+
+import com.khartec.waltz.model.ImmutableEntityReference;
+import com.khartec.waltz.model.thumbnail.ImmutableThumbnail;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class ThumbnailDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void ThumbnailDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new ThumbnailDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    ThumbnailDao thumbnailDao = new ThumbnailDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableThumbnail thumbnail = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    thumbnailDao.create(thumbnail);
+  }
+
+  @Test
+  public void deleteByReferenceTest() throws Exception {
+    // Arrange
+    ThumbnailDao thumbnailDao = new ThumbnailDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference ref = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    thumbnailDao.deleteByReference(ref);
+  }
+
+  @Test
+  public void getByReferenceTest() throws Exception {
+    // Arrange
+    ThumbnailDao thumbnailDao = new ThumbnailDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableEntityReference reference = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    thumbnailDao.getByReference(reference);
+  }
+
+  @Test
+  public void updateTest() throws Exception {
+    // Arrange
+    ThumbnailDao thumbnailDao = new ThumbnailDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableThumbnail thumbnail = null;
+
+    // Act and Assert
+    thrown.expect(NullPointerException.class);
+    thumbnailDao.update(thumbnail);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/user/UserDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/user/UserDaoTest.java
@@ -1,0 +1,86 @@
+package com.khartec.waltz.data.user;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class UserDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void UserDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new UserDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void createTest() throws Exception {
+    // Arrange
+    UserDao userDao = new UserDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String userName = "aaaaa";
+    String passwordHash = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    userDao.create(userName, passwordHash);
+  }
+
+  @Test
+  public void deleteUserTest() throws Exception {
+    // Arrange
+    UserDao userDao = new UserDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String userName = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    userDao.deleteUser(userName);
+  }
+
+  @Test
+  public void findAllUserNamesTest() throws Exception {
+    // Arrange
+    UserDao userDao = new UserDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    userDao.findAllUserNames();
+  }
+
+  @Test
+  public void getPasswordTest() throws Exception {
+    // Arrange
+    UserDao userDao = new UserDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String userName = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    userDao.getPassword(userName);
+  }
+
+  @Test
+  public void resetPasswordTest() throws Exception {
+    // Arrange
+    UserDao userDao = new UserDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String userName = "aaaaa";
+    String passwordHash = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    userDao.resetPassword(userName, passwordHash);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/user/UserPreferenceDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/user/UserPreferenceDaoTest.java
@@ -1,0 +1,81 @@
+package com.khartec.waltz.data.user;
+
+import com.khartec.waltz.model.user.ImmutableUserPreference;
+import com.khartec.waltz.model.user.UserPreference;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class UserPreferenceDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void UserPreferenceDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new UserPreferenceDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void clearPreferencesForUserTest() throws Exception {
+    // Arrange
+    UserPreferenceDao userPreferenceDao = new UserPreferenceDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String userName = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    userPreferenceDao.clearPreferencesForUser(userName);
+  }
+
+  @Test
+  public void getPreferencesForUserTest() throws Exception {
+    // Arrange
+    UserPreferenceDao userPreferenceDao = new UserPreferenceDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String userName = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    userPreferenceDao.getPreferencesForUser(userName);
+  }
+
+  @Test
+  public void savePreferenceTest() throws Exception {
+    // Arrange
+    UserPreferenceDao userPreferenceDao = new UserPreferenceDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String userName = "aaaaa";
+    ImmutableUserPreference preference = null;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    userPreferenceDao.savePreference(userName, preference);
+  }
+
+  @Test
+  public void savePreferencesForUserTest() throws Exception {
+    // Arrange
+    UserPreferenceDao userPreferenceDao = new UserPreferenceDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String userName = "aaaaa";
+    ArrayList<UserPreference> arrayList = new ArrayList<UserPreference>();
+    arrayList.add(null);
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    userPreferenceDao.savePreferencesForUser(userName, arrayList);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/user/UserRoleDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/user/UserRoleDaoTest.java
@@ -1,0 +1,80 @@
+package com.khartec.waltz.data.user;
+
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class UserRoleDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void UserRoleDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new UserRoleDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void deleteUserTest() throws Exception {
+    // Arrange
+    UserRoleDao userRoleDao = new UserRoleDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String userName = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    userRoleDao.deleteUser(userName);
+  }
+
+  @Test
+  public void findAllUsersTest() throws Exception {
+    // Arrange
+    UserRoleDao userRoleDao = new UserRoleDao(new DefaultDSLContext(new DefaultConfiguration()));
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    userRoleDao.findAllUsers();
+  }
+
+  @Test
+  public void getUserRolesTest() throws Exception {
+    // Arrange
+    UserRoleDao userRoleDao = new UserRoleDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String userName = "aaaaa";
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    userRoleDao.getUserRoles(userName);
+  }
+
+  @Test
+  public void updateRolesTest() throws Exception {
+    // Arrange
+    UserRoleDao userRoleDao = new UserRoleDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String userName = "aaaaa";
+    HashSet<String> hashSet = new HashSet<String>();
+    hashSet.add("aaaaa");
+
+    // Act
+    boolean actual = userRoleDao.updateRoles(userName, hashSet);
+
+    // Assert
+    assertFalse(actual);
+  }
+}

--- a/waltz-data/src/test/java/com/khartec/waltz/data/user_agent_info/UserAgentInfoDaoTest.java
+++ b/waltz-data/src/test/java/com/khartec/waltz/data/user_agent_info/UserAgentInfoDaoTest.java
@@ -1,0 +1,54 @@
+package com.khartec.waltz.data.user_agent_info;
+
+import com.khartec.waltz.model.user_agent_info.ImmutableUserAgentInfo;
+import org.jooq.exception.DetachedException;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class UserAgentInfoDaoTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void UserAgentInfoDaoTest() throws Exception {
+    // Arrange
+    DefaultDSLContext defaultDSLContext = new DefaultDSLContext(new DefaultConfiguration());
+
+    // Act
+    new UserAgentInfoDao(defaultDSLContext);
+
+    // Assert
+    assertEquals(
+        "DefaultConfiguration [\n\tconnected=false,\n\ttransactional=false,\n\tdialect=DEFAULT,\n\tdata={},\n\tsettings=\n\t\t<renderCatalog>true</renderCatalog><renderSchema>true</renderSchema><renderNameStyle>QUOTED</renderNameStyle><renderKeywordStyle>AS_IS</renderKeywordStyle><renderFormatted>false</renderFormatted><renderScalarSubqueriesForStoredFunctions>false</renderScalarSubqueriesForStoredFunctions><renderOrderByRownumberForEmulatedPagination>true</renderOrderByRownumberForEmulatedPagination><backslashEscaping>DEFAULT</backslashEscaping><paramType>INDEXED</paramType><paramCastMode>DEFAULT</paramCastMode><statementType>PREPARED_STATEMENT</statementType><executeLogging>true</executeLogging><executeWithOptimisticLocking>false</executeWithOptimisticLocking><executeWithOptimisticLockingExcludeUnversioned>false</executeWithOptimisticLockingExcludeUnversioned><attachRecords>true</attachRecords><updatablePrimaryKeys>false</updatablePrimaryKeys><reflectionCaching>true</reflectionCaching><cacheRecordMappers>true</cacheRecordMappers><throwExceptions>THROW_ALL</throwExceptions><fetchWarnings>true</fetchWarnings><fetchServerOutputSize>0</fetchServerOutputSize><returnAllOnUpdatableRecord>false</returnAllOnUpdatableRecord><returnRecordToPojo>true</returnRecordToPojo><mapJPAAnnotations>true</mapJPAAnnotations><mapConstructorParameterNames>false</mapConstructorParameterNames><queryTimeout>0</queryTimeout><maxRows>0</maxRows><fetchSize>0</fetchSize><debugInfoOnStackTrace>true</debugInfoOnStackTrace><inListPadding>false</inListPadding><inListPadBase>2</inListPadBase><delimiter>;</delimiter><emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly>false</emulateOnDuplicateKeyUpdateOnPrimaryKeyOnly><executeUpdateWithoutWhere>LOG_DEBUG</executeUpdateWithoutWhere><executeDeleteWithoutWhere>LOG_DEBUG</executeDeleteWithoutWhere><parseWithMetaLookups>IGNORE_ON_FAILURE</parseWithMetaLookups><parseUnsupportedSyntax>IGNORE</parseUnsupportedSyntax><parseUnknownFunctions>FAIL</parseUnknownFunctions>\n]",
+        defaultDSLContext.toString());
+  }
+
+  @Test
+  public void findLoginsForUserTest() throws Exception {
+    // Arrange
+    UserAgentInfoDao userAgentInfoDao = new UserAgentInfoDao(new DefaultDSLContext(new DefaultConfiguration()));
+    String userName = "aaaaa";
+    int limit = 1;
+
+    // Act and Assert
+    thrown.expect(DetachedException.class);
+    userAgentInfoDao.findLoginsForUser(userName, limit);
+  }
+
+  @Test
+  public void saveTest() throws Exception {
+    // Arrange
+    UserAgentInfoDao userAgentInfoDao = new UserAgentInfoDao(new DefaultDSLContext(new DefaultConfiguration()));
+    ImmutableUserAgentInfo userAgentInfo = null;
+
+    // Act and Assert
+    thrown.expect(IllegalArgumentException.class);
+    userAgentInfoDao.save(userAgentInfo);
+  }
+}


### PR DESCRIPTION
Feedback on the tests for Waltz
Name of the module: waltz-common

Line coverage with just their tests: 33% (246 lines) 

Line coverage with just our tests: 55% (419 lines)
Line coverage with both sets of tests: 66% (486 lines)
Time -

Name of the module: waltz-data

Line coverage with just their tests: 0% (17 lines) 

Line coverage with just our tests: 40% (3602 lines)
Line coverage with both sets of tests: 40% (3604 lines)
Time -
